### PR TITLE
Agregar CRUD de Pizarra informativa

### DIFF
--- a/api/API/Controllers/InfoBoardController.cs
+++ b/api/API/Controllers/InfoBoardController.cs
@@ -1,0 +1,94 @@
+using Abstracciones.Interfaces.API;
+using Abstracciones.Interfaces.Flujo;
+using Abstracciones.Modelos;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class InfoBoardController : ControllerBase, IInfoBoardController
+    {
+        private readonly IInfoBoardFlujo _infoBoardFlujo;
+        private readonly ILogger<InfoBoardController> _logger;
+
+        public InfoBoardController(IInfoBoardFlujo infoBoardFlujo, ILogger<InfoBoardController> logger)
+        {
+            _infoBoardFlujo = infoBoardFlujo ?? throw new ArgumentNullException(nameof(infoBoardFlujo));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Obtener([FromQuery] bool? activo = true, [FromQuery(Name = "q")] string? busqueda = null)
+        {
+            var resultado = await _infoBoardFlujo.Obtener(activo, busqueda);
+
+            if (!resultado.Any())
+                return NoContent();
+
+            return Ok(resultado);
+        }
+
+        [HttpGet("{id:guid}")]
+        public async Task<IActionResult> Obtener([FromRoute] Guid id)
+        {
+            var item = await _infoBoardFlujo.Obtener(id);
+            if (item == null)
+                return NotFound();
+
+            return Ok(item);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Agregar([FromBody] InfoBoardItemRequest item)
+        {
+            if (!ModelState.IsValid)
+                return ValidationProblem(ModelState);
+
+            /*
+             * Ejemplo de payload:
+             * {
+             *   "titulo": "Charla: Finanzas personales 2025",
+             *   "descripcion": "Inscribite en la charla virtual con cupo limitado.",
+             *   "url": "https://empresa.com/charla-finanzas",
+             *   "tipo": "charla",
+             *   "prioridad": 10,
+             *   "activo": true,
+             *   "fechaInicio": "2025-12-14T00:00:00",
+             *   "fechaFin": "2026-01-14T23:59:59"
+             * }
+             */
+
+            var id = await _infoBoardFlujo.Agregar(item);
+            var creado = await _infoBoardFlujo.Obtener(id);
+            return CreatedAtAction(nameof(Obtener), new { id }, creado);
+        }
+
+        [HttpPut("{id:guid}")]
+        public async Task<IActionResult> Editar([FromRoute] Guid id, [FromBody] InfoBoardItemRequest item)
+        {
+            if (!ModelState.IsValid)
+                return ValidationProblem(ModelState);
+
+            var actual = await _infoBoardFlujo.Obtener(id);
+            if (actual == null)
+                return NotFound();
+
+            await _infoBoardFlujo.Editar(id, item);
+            var actualizado = await _infoBoardFlujo.Obtener(id);
+            return Ok(actualizado);
+        }
+
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> Eliminar([FromRoute] Guid id)
+        {
+            var actual = await _infoBoardFlujo.Obtener(id);
+            if (actual == null)
+                return NotFound();
+
+            await _infoBoardFlujo.Eliminar(id);
+            return NoContent();
+        }
+    }
+}

--- a/api/API/Program.cs
+++ b/api/API/Program.cs
@@ -83,6 +83,8 @@ builder.Services.AddScoped<IUsuarioDA, UsuarioDA>();
 
 builder.Services.AddScoped<IBeneficioImagenDA, BeneficioImagenDA>();
 builder.Services.AddScoped<IBeneficioImagenFlujo, BeneficioImagenFlujo>();
+builder.Services.AddScoped<IInfoBoardDA, InfoBoardDA>();
+builder.Services.AddScoped<IInfoBoardFlujo, InfoBoardFlujo>();
 
 
 

--- a/api/Abstracciones/Interfaces/API/IInfoBoardController.cs
+++ b/api/Abstracciones/Interfaces/API/IInfoBoardController.cs
@@ -1,0 +1,14 @@
+using Abstracciones.Modelos;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Abstracciones.Interfaces.API
+{
+    public interface IInfoBoardController
+    {
+        Task<IActionResult> Obtener([FromQuery] bool? activo, [FromQuery] string? q);
+        Task<IActionResult> Obtener(Guid id);
+        Task<IActionResult> Agregar(InfoBoardItemRequest item);
+        Task<IActionResult> Editar(Guid id, InfoBoardItemRequest item);
+        Task<IActionResult> Eliminar(Guid id);
+    }
+}

--- a/api/Abstracciones/Interfaces/DA/IInfoBoardDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IInfoBoardDA.cs
@@ -1,0 +1,13 @@
+using Abstracciones.Modelos;
+
+namespace Abstracciones.Interfaces.DA
+{
+    public interface IInfoBoardDA
+    {
+        Task<IEnumerable<InfoBoardItemResponse>> Obtener(bool? activo, string? busqueda);
+        Task<InfoBoardItemResponse?> Obtener(Guid id);
+        Task<Guid> Agregar(InfoBoardItemRequest item);
+        Task<Guid> Editar(Guid id, InfoBoardItemRequest item);
+        Task<Guid> Eliminar(Guid id);
+    }
+}

--- a/api/Abstracciones/Interfaces/Flujo/IInfoBoardFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IInfoBoardFlujo.cs
@@ -1,0 +1,13 @@
+using Abstracciones.Modelos;
+
+namespace Abstracciones.Interfaces.Flujo
+{
+    public interface IInfoBoardFlujo
+    {
+        Task<IEnumerable<InfoBoardItemResponse>> Obtener(bool? activo, string? busqueda);
+        Task<InfoBoardItemResponse?> Obtener(Guid id);
+        Task<Guid> Agregar(InfoBoardItemRequest item);
+        Task<Guid> Editar(Guid id, InfoBoardItemRequest item);
+        Task<Guid> Eliminar(Guid id);
+    }
+}

--- a/api/Abstracciones/Modelos/InfoBoardItem.cs
+++ b/api/Abstracciones/Modelos/InfoBoardItem.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Abstracciones.Modelos
+{
+    public class InfoBoardItemBase
+    {
+        [Required, StringLength(120, MinimumLength = 1)]
+        public string Titulo { get; set; } = null!;
+
+        [StringLength(500)]
+        public string? Descripcion { get; set; }
+
+        [Required, StringLength(500), Url]
+        public string Url { get; set; } = null!;
+
+        [StringLength(50)]
+        public string? Tipo { get; set; }
+
+        public int Prioridad { get; set; } = 0;
+
+        public bool Activo { get; set; } = true;
+
+        public DateTime? FechaInicio { get; set; }
+
+        public DateTime? FechaFin { get; set; }
+    }
+
+    public class InfoBoardItemRequest : InfoBoardItemBase
+    {
+    }
+
+    public class InfoBoardItemResponse : InfoBoardItemBase
+    {
+        public Guid InfoBoardItemId { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/api/BD/BD.sqlproj
+++ b/api/BD/BD.sqlproj
@@ -111,5 +111,11 @@
     <Build Include="core\Stored Procedures\ObtenerBeneficiosAprobados.sql" />
     <Build Include="core\Stored Procedures\ExisteProveedor.sql" />
     <Build Include="core\Stored Procedures\AprobarBeneficio.sql" />
+    <Build Include="core\Tables\InfoBoardItem.sql" />
+    <Build Include="core\Stored Procedures\InfoBoardItem_Agregar.sql" />
+    <Build Include="core\Stored Procedures\InfoBoardItem_Editar.sql" />
+    <Build Include="core\Stored Procedures\InfoBoardItem_Eliminar.sql" />
+    <Build Include="core\Stored Procedures\InfoBoardItem_Listar.sql" />
+    <Build Include="core\Stored Procedures\InfoBoardItem_ObtenerPorId.sql" />
   </ItemGroup>
 </Project>

--- a/api/BD/core/Stored Procedures/InfoBoardItem_Agregar.sql
+++ b/api/BD/core/Stored Procedures/InfoBoardItem_Agregar.sql
@@ -1,0 +1,22 @@
+CREATE PROCEDURE [core].[InfoBoardItem_Agregar]
+    @Titulo       NVARCHAR(120),
+    @Descripcion  NVARCHAR(500) = NULL,
+    @Url          NVARCHAR(500),
+    @Tipo         NVARCHAR(50) = NULL,
+    @Prioridad    INT = 0,
+    @Activo       BIT = 1,
+    @FechaInicio  DATETIME2(7) = NULL,
+    @FechaFin     DATETIME2(7) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @Id UNIQUEIDENTIFIER = NEWID();
+
+    INSERT INTO core.InfoBoardItem
+        (InfoBoardItemId, Titulo, Descripcion, Url, Tipo, Prioridad, Activo, FechaInicio, FechaFin, CreatedAt, UpdatedAt, IsDeleted)
+    VALUES
+        (@Id, @Titulo, @Descripcion, @Url, @Tipo, ISNULL(@Prioridad, 0), ISNULL(@Activo, 1), @FechaInicio, @FechaFin, SYSUTCDATETIME(), SYSUTCDATETIME(), 0);
+
+    SELECT @Id AS InfoBoardItemId;
+END
+GO

--- a/api/BD/core/Stored Procedures/InfoBoardItem_Editar.sql
+++ b/api/BD/core/Stored Procedures/InfoBoardItem_Editar.sql
@@ -1,0 +1,30 @@
+CREATE PROCEDURE [core].[InfoBoardItem_Editar]
+    @InfoBoardItemId UNIQUEIDENTIFIER,
+    @Titulo          NVARCHAR(120),
+    @Descripcion     NVARCHAR(500) = NULL,
+    @Url             NVARCHAR(500),
+    @Tipo            NVARCHAR(50) = NULL,
+    @Prioridad       INT = 0,
+    @Activo          BIT = 1,
+    @FechaInicio     DATETIME2(7) = NULL,
+    @FechaFin        DATETIME2(7) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE core.InfoBoardItem
+    SET Titulo = @Titulo,
+        Descripcion = @Descripcion,
+        Url = @Url,
+        Tipo = @Tipo,
+        Prioridad = ISNULL(@Prioridad, 0),
+        Activo = ISNULL(@Activo, 1),
+        FechaInicio = @FechaInicio,
+        FechaFin = @FechaFin,
+        UpdatedAt = SYSUTCDATETIME()
+    WHERE InfoBoardItemId = @InfoBoardItemId
+      AND IsDeleted = 0;
+
+    SELECT @InfoBoardItemId AS InfoBoardItemId;
+END
+GO

--- a/api/BD/core/Stored Procedures/InfoBoardItem_Eliminar.sql
+++ b/api/BD/core/Stored Procedures/InfoBoardItem_Eliminar.sql
@@ -1,0 +1,15 @@
+CREATE PROCEDURE [core].[InfoBoardItem_Eliminar]
+    @InfoBoardItemId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE core.InfoBoardItem
+    SET IsDeleted = 1,
+        Activo = 0,
+        UpdatedAt = SYSUTCDATETIME()
+    WHERE InfoBoardItemId = @InfoBoardItemId;
+
+    SELECT @InfoBoardItemId AS InfoBoardItemId;
+END
+GO

--- a/api/BD/core/Stored Procedures/InfoBoardItem_Listar.sql
+++ b/api/BD/core/Stored Procedures/InfoBoardItem_Listar.sql
@@ -1,0 +1,39 @@
+CREATE PROCEDURE [core].[InfoBoardItem_Listar]
+    @Activo   BIT = 1,
+    @Busqueda NVARCHAR(200) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @Ahora DATETIME2(7) = SYSUTCDATETIME();
+
+    SELECT InfoBoardItemId,
+           Titulo,
+           Descripcion,
+           Url,
+           Tipo,
+           Prioridad,
+           Activo,
+           FechaInicio,
+           FechaFin,
+           CreatedAt,
+           UpdatedAt
+    FROM core.InfoBoardItem
+    WHERE IsDeleted = 0
+      AND (@Activo IS NULL OR Activo = @Activo)
+      AND (
+            @Activo IS NULL
+            OR @Activo = 0
+            OR (
+                (FechaInicio IS NULL OR FechaInicio <= @Ahora)
+                AND (FechaFin IS NULL OR FechaFin >= @Ahora)
+            )
+      )
+      AND (
+            @Busqueda IS NULL
+            OR LTRIM(RTRIM(@Busqueda)) = ''
+            OR Titulo LIKE '%' + @Busqueda + '%'
+            OR Descripcion LIKE '%' + @Busqueda + '%'
+      )
+    ORDER BY Prioridad DESC, CreatedAt DESC;
+END
+GO

--- a/api/BD/core/Stored Procedures/InfoBoardItem_ObtenerPorId.sql
+++ b/api/BD/core/Stored Procedures/InfoBoardItem_ObtenerPorId.sql
@@ -1,0 +1,22 @@
+CREATE PROCEDURE [core].[InfoBoardItem_ObtenerPorId]
+    @InfoBoardItemId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT InfoBoardItemId,
+           Titulo,
+           Descripcion,
+           Url,
+           Tipo,
+           Prioridad,
+           Activo,
+           FechaInicio,
+           FechaFin,
+           CreatedAt,
+           UpdatedAt
+    FROM core.InfoBoardItem
+    WHERE InfoBoardItemId = @InfoBoardItemId
+      AND IsDeleted = 0;
+END
+GO

--- a/api/BD/core/Tables/InfoBoardItem.sql
+++ b/api/BD/core/Tables/InfoBoardItem.sql
@@ -1,0 +1,47 @@
+CREATE TABLE [core].[InfoBoardItem] (
+    [InfoBoardItemId] UNIQUEIDENTIFIER CONSTRAINT [DF_InfoBoardItem_InfoBoardItemId] DEFAULT (newid()) NOT NULL,
+    [Titulo]          NVARCHAR (120)   NOT NULL,
+    [Descripcion]     NVARCHAR (500)   NULL,
+    [Url]             NVARCHAR (500)   NOT NULL,
+    [Tipo]            NVARCHAR (50)    NULL,
+    [Prioridad]       INT              CONSTRAINT [DF_InfoBoardItem_Prioridad] DEFAULT ((0)) NOT NULL,
+    [Activo]          BIT              CONSTRAINT [DF_InfoBoardItem_Activo] DEFAULT ((1)) NOT NULL,
+    [FechaInicio]     DATETIME2 (7)    NULL,
+    [FechaFin]        DATETIME2 (7)    NULL,
+    [CreatedAt]       DATETIME2 (7)    CONSTRAINT [DF_InfoBoardItem_CreatedAt] DEFAULT (sysutcdatetime()) NOT NULL,
+    [UpdatedAt]       DATETIME2 (7)    CONSTRAINT [DF_InfoBoardItem_UpdatedAt] DEFAULT (sysutcdatetime()) NOT NULL,
+    [IsDeleted]       BIT              CONSTRAINT [DF_InfoBoardItem_IsDeleted] DEFAULT ((0)) NOT NULL,
+    CONSTRAINT [PK_InfoBoardItem] PRIMARY KEY CLUSTERED ([InfoBoardItemId] ASC),
+    CONSTRAINT [CK_InfoBoardItem_Titulo] CHECK ([Titulo] IS NOT NULL AND len([Titulo]) >= (1) AND len([Titulo]) <= (120)),
+    CONSTRAINT [CK_InfoBoardItem_Url] CHECK ([Url] IS NOT NULL AND len([Url]) >= (1) AND len([Url]) <= (500))
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_InfoBoardItem_Activo_Prioridad]
+    ON [core].[InfoBoardItem]([Activo] ASC, [Prioridad] DESC, [CreatedAt] DESC)
+    INCLUDE([FechaInicio], [FechaFin]);
+GO
+
+IF NOT EXISTS (SELECT 1 FROM [core].[InfoBoardItem] WHERE [Titulo] = N'Charla: Finanzas personales 2025')
+BEGIN
+    INSERT INTO [core].[InfoBoardItem] (Titulo, Descripcion, Url, Tipo, Prioridad, Activo, FechaInicio, FechaFin)
+    VALUES
+    (N'Charla: Finanzas personales 2025', N'Inscribite en la charla virtual con cupo limitado.', N'https://empresa.com/charla-finanzas', N'charla', 10, 1, '2025-12-14T00:00:00', '2026-01-14T23:59:59');
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM [core].[InfoBoardItem] WHERE [Titulo] = N'Campaña: Salud y bienestar')
+BEGIN
+    INSERT INTO [core].[InfoBoardItem] (Titulo, Descripcion, Url, Tipo, Prioridad, Activo, FechaInicio, FechaFin)
+    VALUES
+    (N'Campaña: Salud y bienestar', N'Consejos y recursos para mantener un estilo de vida saludable.', N'https://empresa.com/campana-salud', N'campaña', 5, 1, NULL, NULL);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM [core].[InfoBoardItem] WHERE [Titulo] = N'Link de encuesta de satisfacción')
+BEGIN
+    INSERT INTO [core].[InfoBoardItem] (Titulo, Descripcion, Url, Tipo, Prioridad, Activo, FechaInicio, FechaFin)
+    VALUES
+    (N'Link de encuesta de satisfacción', N'Contanos tu experiencia con los beneficios.', N'https://empresa.com/encuesta-beneficios', N'link', 1, 1, NULL, NULL);
+END;
+GO

--- a/api/DA/InfoBoardDA.cs
+++ b/api/DA/InfoBoardDA.cs
@@ -1,0 +1,128 @@
+using Abstracciones.Interfaces.DA;
+using Abstracciones.Modelos;
+using System.Data;
+using System.Linq;
+
+namespace DA
+{
+    public class InfoBoardDA : IInfoBoardDA
+    {
+        private readonly IRepositorioDapper _repositorioDapper;
+        private readonly IDapperWrapper _dapperWrapper;
+        private readonly IDbConnection _dbConnection;
+
+        public InfoBoardDA(IRepositorioDapper repositorioDapper, IDapperWrapper dapperWrapper)
+        {
+            _repositorioDapper = repositorioDapper ?? throw new ArgumentNullException(nameof(repositorioDapper));
+            _dapperWrapper = dapperWrapper ?? throw new ArgumentNullException(nameof(dapperWrapper));
+            _dbConnection = _repositorioDapper.ObtenerRepositorio();
+        }
+
+        public async Task<Guid> Agregar(InfoBoardItemRequest item)
+        {
+            const string sp = "core.InfoBoardItem_Agregar";
+            var id = await _dapperWrapper.ExecuteScalarAsync<Guid>(
+                _dbConnection,
+                sp,
+                new
+                {
+                    item.Titulo,
+                    item.Descripcion,
+                    item.Url,
+                    item.Tipo,
+                    item.Prioridad,
+                    item.Activo,
+                    item.FechaInicio,
+                    item.FechaFin
+                },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return id;
+        }
+
+        public async Task<Guid> Editar(Guid id, InfoBoardItemRequest item)
+        {
+            await VerificarExiste(id);
+
+            const string sp = "core.InfoBoardItem_Editar";
+            var resultado = await _dapperWrapper.ExecuteScalarAsync<Guid>(
+                _dbConnection,
+                sp,
+                new
+                {
+                    InfoBoardItemId = id,
+                    item.Titulo,
+                    item.Descripcion,
+                    item.Url,
+                    item.Tipo,
+                    item.Prioridad,
+                    item.Activo,
+                    item.FechaInicio,
+                    item.FechaFin
+                },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return resultado;
+        }
+
+        public async Task<Guid> Eliminar(Guid id)
+        {
+            await VerificarExiste(id);
+
+            const string sp = "core.InfoBoardItem_Eliminar";
+            var resultado = await _dapperWrapper.ExecuteScalarAsync<Guid>(
+                _dbConnection,
+                sp,
+                new { InfoBoardItemId = id },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return resultado;
+        }
+
+        public async Task<IEnumerable<InfoBoardItemResponse>> Obtener(bool? activo, string? busqueda)
+        {
+            const string sp = "core.InfoBoardItem_Listar";
+            var rows = await _dapperWrapper.QueryAsync<InfoBoardItemResponse>(
+                _dbConnection,
+                sp,
+                new { Activo = activo, Busqueda = busqueda },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return rows;
+        }
+
+        public async Task<InfoBoardItemResponse?> Obtener(Guid id)
+        {
+            const string sp = "core.InfoBoardItem_ObtenerPorId";
+            var rows = await _dapperWrapper.QueryAsync<InfoBoardItemResponse>(
+                _dbConnection,
+                sp,
+                new { InfoBoardItemId = id },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return rows.FirstOrDefault();
+        }
+
+        private async Task VerificarExiste(Guid id)
+        {
+            var item = await Obtener(id);
+            if (item == null)
+                throw new Exception("No se encontro el item de pizarra");
+        }
+    }
+}

--- a/api/Flujo/InfoBoardFlujo.cs
+++ b/api/Flujo/InfoBoardFlujo.cs
@@ -1,0 +1,41 @@
+using Abstracciones.Interfaces.DA;
+using Abstracciones.Interfaces.Flujo;
+using Abstracciones.Modelos;
+
+namespace Flujo
+{
+    public class InfoBoardFlujo : IInfoBoardFlujo
+    {
+        private readonly IInfoBoardDA _infoBoardDA;
+
+        public InfoBoardFlujo(IInfoBoardDA infoBoardDA)
+        {
+            _infoBoardDA = infoBoardDA ?? throw new ArgumentNullException(nameof(infoBoardDA));
+        }
+
+        public async Task<Guid> Agregar(InfoBoardItemRequest item)
+        {
+            return await _infoBoardDA.Agregar(item);
+        }
+
+        public async Task<Guid> Editar(Guid id, InfoBoardItemRequest item)
+        {
+            return await _infoBoardDA.Editar(id, item);
+        }
+
+        public async Task<Guid> Eliminar(Guid id)
+        {
+            return await _infoBoardDA.Eliminar(id);
+        }
+
+        public async Task<IEnumerable<InfoBoardItemResponse>> Obtener(bool? activo, string? busqueda)
+        {
+            return await _infoBoardDA.Obtener(activo, busqueda);
+        }
+
+        public async Task<InfoBoardItemResponse?> Obtener(Guid id)
+        {
+            return await _infoBoardDA.Obtener(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- agrega el recurso InfoBoardItem con contratos, flujo y controlador API siguiendo la arquitectura existente
- implementa la capa de datos con procedimientos almacenados para listar, obtener, crear, editar y eliminar con filtros de vigencia y activo
- crea la tabla InfoBoardItem con datos seed y registra las dependencias en el contenedor

## Testing
- dotnet build (no disponible en el entorno de ejecución)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef9d2de148322a133de80abcbf204)