### PR TITLE
Integrate InfoBoard API for landing modal and admin CRUD

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminMain.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminMain.jsx
@@ -5,6 +5,7 @@ import DashboardBeneficios from "./pages/DashboardBeneficios";
 import CategoriasPage from "./pages/CategoriasPage";
 import ProveedoresPage from "./pages/ProveedoresPage";
 import AprobacionesPage from "./pages/AprobacionesPage";
+import InfoBoardPage from "./pages/InfoBoardPage";
 
 export default function AdminMain(props) {
   const {
@@ -57,6 +58,7 @@ export default function AdminMain(props) {
             addProveedor={addProveedor}
           />
         )}
+        {nav === NAV_ITEMS.INFOBOARD && <InfoBoardPage />}
         {nav === NAV_ITEMS.APROBACIONES && (
           <AprobacionesPage />
         )}

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminShell.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminShell.jsx
@@ -1,4 +1,6 @@
 // src/components/AdminShell/AdminShell.jsx
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import Sidebar from "../sidebar/Sidebar";
 import MobileSidebar from "../sidebar/MobileSidebar";
 import AdminHeader from "./AdminHeader";
@@ -7,6 +9,8 @@ import useAdminShell from "./useAdminShell";
 import { MOBILE_ITEMS, NAV_ITEMS } from "./constants";
 
 export default function AdminShell() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const {
     nav,
     setNav,
@@ -34,6 +38,33 @@ export default function AdminShell() {
     }
     setNav(key);
   };
+
+  useEffect(() => {
+    const path = location.pathname.toLowerCase();
+    if (path.includes("/admin/infoboard")) setNav(NAV_ITEMS.INFOBOARD);
+    else if (path.includes("/admin/categorias")) setNav(NAV_ITEMS.CATEGORIAS);
+    else if (path.includes("/admin/proveedores")) setNav(NAV_ITEMS.PROVEEDORES);
+    else if (path.includes("/admin/aprobaciones")) setNav(NAV_ITEMS.APROBACIONES);
+    else if (!path.includes("/admin")) setNav(NAV_ITEMS.BENEFICIOS);
+    else setNav((prev) => prev || NAV_ITEMS.BENEFICIOS);
+  }, [location.pathname, setNav]);
+
+  useEffect(() => {
+    const nextPath =
+      nav === NAV_ITEMS.INFOBOARD
+        ? "/admin/infoboard"
+        : nav === NAV_ITEMS.CATEGORIAS
+          ? "/admin/categorias"
+          : nav === NAV_ITEMS.PROVEEDORES
+            ? "/admin/proveedores"
+            : nav === NAV_ITEMS.APROBACIONES
+              ? "/admin/aprobaciones"
+              : "/admin";
+
+    if (location.pathname !== nextPath) {
+      navigate(nextPath, { replace: true });
+    }
+  }, [nav, navigate, location.pathname]);
 
   return (
     <div className="min-h-screen bg-neutral-950 text-white flex flex-col md:flex-row">

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/constants.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/constants.js
@@ -3,6 +3,7 @@ export const NAV_ITEMS = {
   BENEFICIOS: "beneficios",
   CATEGORIAS: "categorias",
   PROVEEDORES: "proveedores",
+  INFOBOARD: "infoboard",
   HRPORTAL: "hrportal",
   APROBACIONES: "aprobaciones",
 };
@@ -11,6 +12,7 @@ export const MOBILE_ITEMS = [
   { key: NAV_ITEMS.BENEFICIOS, label: "Beneficios" },
   { key: NAV_ITEMS.CATEGORIAS, label: "Categorías" },
   { key: NAV_ITEMS.PROVEEDORES, label: "Proveedores" },
+  { key: NAV_ITEMS.INFOBOARD, label: "InfoBoard" },
   { key: NAV_ITEMS.HRPORTAL, label: "HR Portal", href: "http://hrportal" },
   { key: NAV_ITEMS.APROBACIONES, label: "Aprobaciones" },
 ];

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/InfoBoardPage.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/InfoBoardPage.jsx
@@ -1,0 +1,384 @@
+import { useEffect, useMemo, useState } from "react";
+import { create, getById, list, mapInfoBoard, remove, update } from "../../../services/infoBoardService";
+import { useConfirm } from "../../ui/ConfirmGlobal";
+
+const blankForm = {
+  titulo: "",
+  descripcion: "",
+  url: "",
+  tipo: "",
+  prioridad: 0,
+  activo: true,
+  fechaInicio: "",
+  fechaFin: "",
+};
+
+const toDateInput = (v) => (v ? String(v).slice(0, 10) : "");
+const normalizeUrl = (v) => (typeof v === "string" ? v.trim() : "");
+const normalizeText = (v) => (typeof v === "string" ? v.trim() : "");
+
+export default function InfoBoardPage() {
+  const confirm = useConfirm();
+
+  const [items, setItems] = useState([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const [listError, setListError] = useState("");
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [selectedId, setSelectedId] = useState(null);
+  const [form, setForm] = useState(blankForm);
+  const [formError, setFormError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [query, setQuery] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [activoFilter, setActivoFilter] = useState("true");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(query.trim()), 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        setLoadingList(true);
+        setListError("");
+        const activoValue = activoFilter === "" ? null : activoFilter === "true";
+        const data = await list({
+          activo: activoValue,
+          q: debouncedQ,
+        });
+        if (!alive) return;
+        const mapped = Array.isArray(data) ? data.map(mapInfoBoard) : [];
+        setItems(mapped);
+
+        if (selectedId) {
+          const still = mapped.find((i) => i.id === selectedId);
+          if (!still) {
+            setSelectedId(null);
+            setForm(blankForm);
+          }
+        }
+      } catch (err) {
+        if (!alive) return;
+        setListError(err?.message || "No se pudo cargar la pizarra.");
+      } finally {
+        if (alive) setLoadingList(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [debouncedQ, activoFilter]);
+
+  const selectedItem = useMemo(
+    () => items.find((i) => i.id === selectedId) || null,
+    [items, selectedId]
+  );
+
+  async function handleSelect(item) {
+    const id = typeof item === "object" ? item?.id : item;
+    if (!id) {
+      setSelectedId(null);
+      setForm(blankForm);
+      setFormError("");
+      return;
+    }
+
+    setSelectedId(id);
+    setFormError("");
+
+    if (item && typeof item === "object") {
+      setForm({ ...blankForm, ...item, fechaInicio: toDateInput(item.fechaInicio), fechaFin: toDateInput(item.fechaFin) });
+      return;
+    }
+
+    try {
+      setLoadingDetail(true);
+      const raw = await getById(id);
+      const mapped = mapInfoBoard(raw);
+      setForm({ ...blankForm, ...mapped, fechaInicio: toDateInput(mapped.fechaInicio), fechaFin: toDateInput(mapped.fechaFin) });
+    } catch (err) {
+      setFormError(err?.message || "No se pudo cargar el detalle.");
+    } finally {
+      setLoadingDetail(false);
+    }
+  }
+
+  function validate() {
+    if (!normalizeText(form.titulo)) return "El título es obligatorio.";
+    const url = normalizeUrl(form.url);
+    if (!url) return "La URL es obligatoria.";
+    if (!/^https?:\/\//i.test(url)) return "La URL debe iniciar con http o https.";
+    return "";
+  }
+
+  async function handleSubmit(e) {
+    e?.preventDefault();
+    const errMsg = validate();
+    if (errMsg) {
+      setFormError(errMsg);
+      return;
+    }
+
+    const payload = {
+      Titulo: normalizeText(form.titulo),
+      Descripcion: normalizeText(form.descripcion),
+      Url: normalizeUrl(form.url),
+      Tipo: normalizeText(form.tipo) || null,
+      Prioridad: Number(form.prioridad) || 0,
+      Activo: Boolean(form.activo),
+      FechaInicio: form.fechaInicio || null,
+      FechaFin: form.fechaFin || null,
+    };
+
+    try {
+      setSaving(true);
+      setFormError("");
+      let targetId = selectedId;
+      if (selectedId) {
+        await update(selectedId, payload);
+        targetId = selectedId;
+      } else {
+        const created = await create(payload);
+        targetId = typeof created === "string" ? created : created?.infoBoardItemId || created?.InfoBoardItemId || created?.id;
+      }
+      await handleSelect(null);
+      const activoValue = activoFilter === "" ? null : activoFilter === "true";
+      const data = await list({ activo: activoValue, q: debouncedQ });
+      const mapped = Array.isArray(data) ? data.map(mapInfoBoard) : [];
+      setItems(mapped);
+      const match = mapped.find((i) => i.id === targetId);
+      if (match) {
+        setSelectedId(match.id);
+        setForm({ ...blankForm, ...match, fechaInicio: toDateInput(match.fechaInicio), fechaFin: toDateInput(match.fechaFin) });
+      }
+    } catch (err) {
+      setFormError(err?.message || "No se pudo guardar el anuncio.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!selectedId) return;
+    const ok = await confirm("¿Eliminar este anuncio?", { okText: "Eliminar", cancelText: "Cancelar" });
+    if (!ok) return;
+    try {
+      await remove(selectedId);
+      setSelectedId(null);
+      setForm(blankForm);
+      const activoValue = activoFilter === "" ? null : activoFilter === "true";
+      const data = await list({ activo: activoValue, q: debouncedQ });
+      setItems(Array.isArray(data) ? data.map(mapInfoBoard) : []);
+    } catch (err) {
+      setFormError(err?.message || "No se pudo eliminar el anuncio.");
+    }
+  }
+
+  const empty = !loadingList && !listError && items.length === 0;
+
+  return (
+    <section className="space-y-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <div className="flex items-center gap-2">
+            <label className="text-sm text-white/70">Activo</label>
+            <select
+              className="bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+              value={activoFilter}
+              onChange={(e) => setActivoFilter(e.target.value)}
+            >
+              <option value="">Todos</option>
+              <option value="true">Solo activos</option>
+              <option value="false">Inactivos</option>
+            </select>
+          </div>
+          <input
+            type="search"
+            placeholder="Buscar…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm w-full sm:w-64"
+          />
+        </div>
+        <button
+          onClick={() => handleSelect(null)}
+          className="px-3 py-2 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90"
+        >
+          + Nuevo
+        </button>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(320px,420px)_1fr]">
+        <div className="rounded-2xl border border-white/10 bg-black/40 divide-y divide-white/5">
+          {loadingList && (
+            <p className="px-4 py-3 text-sm text-white/60">Cargando…</p>
+          )}
+          {listError && (
+            <p className="px-4 py-3 text-sm text-red-300" role="alert">{listError}</p>
+          )}
+          {items.map((item) => {
+            const active = selectedId === item.id;
+            return (
+              <button
+                key={item.id}
+                onClick={() => handleSelect(item)}
+                className={`w-full text-left px-4 py-3 transition border-l-4 ${
+                  active ? "bg-white/5 border-emerald-400/80" : "border-transparent hover:bg-white/5"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold truncate">{item.titulo || "(Sin título)"}</p>
+                    <p className="text-xs text-white/50 truncate">
+                      {item.tipo || "—"} • Prioridad {item.prioridad ?? 0}
+                    </p>
+                    <p className="text-xs text-white/40 truncate">
+                      {item.fechaInicio || item.fechaFin
+                        ? `${toDateInput(item.fechaInicio) || ""}${item.fechaFin ? ` → ${toDateInput(item.fechaFin)}` : ""}`
+                        : "Sin vigencia"}
+                    </p>
+                  </div>
+                  <span
+                    className={`text-xs px-2 py-1 rounded-full border ${
+                      item.activo
+                        ? "border-emerald-400/40 text-emerald-200 bg-emerald-400/10"
+                        : "border-white/10 text-white/60"
+                    }`}
+                  >
+                    {item.activo ? "Activo" : "Inactivo"}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+          {empty && (
+            <p className="px-4 py-6 text-xs text-white/50">No hay anuncios para los filtros aplicados.</p>
+          )}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-white/10 bg-black/50 p-4 space-y-3"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">{selectedItem ? "Editar" : "Nuevo anuncio"}</h3>
+              <p className="text-xs text-white/50">Define la tarjeta que verán los colaboradores.</p>
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm text-white/80">
+              <input
+                type="checkbox"
+                checked={form.activo}
+                onChange={(e) => setForm((s) => ({ ...s, activo: e.target.checked }))}
+                className="accent-emerald-400 w-4 h-4"
+              />
+              Activo
+            </label>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label className="block text-xs text-white/60 mb-1">Título *</label>
+              <input
+                value={form.titulo}
+                onChange={(e) => setForm((s) => ({ ...s, titulo: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+                required
+              />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="block text-xs text-white/60 mb-1">Descripción</label>
+              <textarea
+                value={form.descripcion}
+                onChange={(e) => setForm((s) => ({ ...s, descripcion: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm min-h-[90px]"
+              />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="block text-xs text-white/60 mb-1">URL *</label>
+              <input
+                value={form.url}
+                onChange={(e) => setForm((s) => ({ ...s, url: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+                placeholder="https://"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs text-white/60 mb-1">Tipo</label>
+              <input
+                value={form.tipo}
+                onChange={(e) => setForm((s) => ({ ...s, tipo: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs text-white/60 mb-1">Prioridad</label>
+              <input
+                type="number"
+                value={form.prioridad}
+                onChange={(e) => setForm((s) => ({ ...s, prioridad: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs text-white/60 mb-1">Fecha inicio</label>
+              <input
+                type="date"
+                value={form.fechaInicio}
+                onChange={(e) => setForm((s) => ({ ...s, fechaInicio: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs text-white/60 mb-1">Fecha fin</label>
+              <input
+                type="date"
+                value={form.fechaFin}
+                onChange={(e) => setForm((s) => ({ ...s, fechaFin: e.target.value }))}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          {formError && (
+            <p className="text-sm text-red-300" role="alert">{formError}</p>
+          )}
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-xl bg-[var(--brand)] text-sm font-semibold hover:opacity-90 disabled:opacity-60"
+            >
+              {saving ? "Guardando…" : "Guardar"}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleSelect(selectedItem)}
+              className="px-4 py-2 rounded-xl border border-white/10 text-sm"
+            >
+              Cancelar
+            </button>
+            {selectedId && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="px-4 py-2 rounded-xl border border-red-400/50 text-sm text-red-200 hover:bg-red-500/10"
+              >
+                Eliminar
+              </button>
+            )}
+            {loadingDetail && <span className="text-xs text-white/50">Cargando detalle…</span>}
+          </div>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/components/sidebar/MobileSidebar.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/sidebar/MobileSidebar.jsx
@@ -52,6 +52,13 @@ const IconShield = (p) => (
   </svg>
 );
 
+const IconBoard = (p) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...p}>
+    <rect x="4" y="5" width="16" height="14" rx="2" strokeWidth="1.8" />
+    <path d="M8 9h8M8 13h5" strokeWidth="1.8" strokeLinecap="round" />
+  </svg>
+);
+
 /* ================================================== */
 
 export default function MobileSidebar({ open, current, items, onSelect, onClose }) {
@@ -132,6 +139,8 @@ export default function MobileSidebar({ open, current, items, onSelect, onClose 
               iconNode = <IconBuilding className="w-5 h-5" />;
             } else if (i.key === "aprobaciones") {
               iconNode = <IconShield className="w-5 h-5" />;
+            } else if (i.key === "infoboard") {
+              iconNode = <IconBoard className="w-5 h-5" />;
             }
 
             const rowClasses = `

--- a/clon/AdminBeneficiosFinalPublicado/src/components/sidebar/Sidebar.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/sidebar/Sidebar.jsx
@@ -51,6 +51,13 @@ const IconShield = (p) => (
   </svg>
 );
 
+const IconBoard = (p) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...p}>
+    <rect x="4" y="5" width="16" height="14" rx="2" strokeWidth="1.8" />
+    <path d="M8 9h8M8 13h5" strokeWidth="1.8" strokeLinecap="round" />
+  </svg>
+);
+
 const LS_SIDEBAR = "admin.sidebar.collapsed";
 
 export default function Sidebar({
@@ -100,6 +107,14 @@ export default function Sidebar({
           active={nav === "proveedores"}
           collapsed={collapsed}
           onClick={() => onChangeNav("proveedores")}
+        />
+
+        <NavItem
+          label="InfoBoard"
+          icon={<IconBoard className="w-5 h-5" />}
+          active={nav === "infoboard"}
+          collapsed={collapsed}
+          onClick={() => onChangeNav("infoboard")}
         />
 
         {/* HR Portal como link externo independiente */}

--- a/clon/AdminBeneficiosFinalPublicado/src/services/infoBoardService.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/services/infoBoardService.js
@@ -1,0 +1,49 @@
+const API_BASE = (import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
+
+async function request(path, { method = "GET", json, expectList = false } = {}) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Accept: "application/json",
+      ...(json ? { "Content-Type": "application/json" } : {}),
+    },
+    body: json ? JSON.stringify(json) : undefined,
+    mode: "cors",
+  });
+
+  if (res.status === 204) return expectList ? [] : null;
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}`);
+
+  const ct = res.headers.get("content-type") || "";
+  return ct.includes("application/json") ? res.json() : res.text();
+}
+
+const normalize = (v) => (typeof v === "string" ? v.trim() : v ?? "");
+const toBool = (v) => Boolean(v === true || v === "true" || v === 1 || v === "1");
+
+export function mapInfoBoard(raw) {
+  return {
+    id: raw?.infoBoardItemId ?? raw?.InfoBoardItemId ?? raw?.id ?? raw?.Id,
+    titulo: normalize(raw?.titulo ?? raw?.Titulo),
+    descripcion: normalize(raw?.descripcion ?? raw?.Descripcion),
+    url: normalize(raw?.url ?? raw?.Url),
+    tipo: normalize(raw?.tipo ?? raw?.Tipo),
+    prioridad: Number(raw?.prioridad ?? raw?.Prioridad ?? 0) || 0,
+    activo: toBool(raw?.activo ?? raw?.Activo ?? raw?.activa ?? raw?.Activa),
+    fechaInicio: normalize(raw?.fechaInicio ?? raw?.FechaInicio ?? ""),
+    fechaFin: normalize(raw?.fechaFin ?? raw?.FechaFin ?? ""),
+  };
+}
+
+export async function list({ activo, q } = {}) {
+  const params = new URLSearchParams();
+  if (activo !== undefined && activo !== null) params.set("activo", String(activo));
+  if (q) params.set("q", q.trim());
+  const qs = params.toString();
+  return request(`/api/InfoBoard${qs ? `?${qs}` : ""}`, { expectList: true });
+}
+
+export const getById = (id) => request(`/api/InfoBoard/${id}`);
+export const create = (payload) => request(`/api/InfoBoard`, { method: "POST", json: payload });
+export const update = (id, payload) => request(`/api/InfoBoard/${id}`, { method: "PUT", json: payload });
+export const remove = (id) => request(`/api/InfoBoard/${id}`, { method: "DELETE" });

--- a/clon/InicioBeneficiosFinalPublicado/src/components/InfoBoardModal/InfoBoardModal.css
+++ b/clon/InicioBeneficiosFinalPublicado/src/components/InfoBoardModal/InfoBoardModal.css
@@ -62,5 +62,92 @@
   font-size: 18px;
   line-height: 1.6;
   opacity: 0.92;
+}
 
+.info-modal-search {
+  margin: 16px 0 12px;
+}
+
+.info-modal-search input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+}
+
+.info-modal-search input:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+}
+
+.info-modal-hint,
+.info-modal-error {
+  margin: 12px 2px;
+  font-size: 14px;
+}
+
+.info-modal-error {
+  color: #fca5a5;
+}
+
+.info-modal-list {
+  display: grid;
+  gap: 12px;
+}
+
+.info-modal-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.info-modal-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.info-modal-card-title {
+  margin: 0;
+  font-size: 18px;
+}
+
+.info-modal-chip {
+  display: inline-flex;
+  margin-top: 6px;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  width: fit-content;
+}
+
+.info-modal-card-desc {
+  margin: 12px 0 0;
+  opacity: 0.85;
+  font-size: 14px;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.info-modal-open {
+  background: #fff;
+  color: #000;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.info-modal-open:hover {
+  background: #f3f4f6;
 }

--- a/clon/InicioBeneficiosFinalPublicado/src/components/InfoBoardModal/InfoBoardModal.jsx
+++ b/clon/InicioBeneficiosFinalPublicado/src/components/InfoBoardModal/InfoBoardModal.jsx
@@ -1,6 +1,41 @@
+import { useEffect, useMemo, useState } from "react";
+import { getInfoBoard, mapInfoBoardItem } from "../../services/infoBoardService";
 import "./InfoBoardModal.css";
 
 export default function InfoBoardModal({ open, onClose }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(query.trim()), 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError("");
+        const data = await getInfoBoard({ activo: true, q: debouncedQ });
+        if (!alive) return;
+        setItems(Array.isArray(data) ? data.map(mapInfoBoardItem) : []);
+      } catch (err) {
+        if (!alive) return;
+        setError(err?.message || "No se pudo cargar la pizarra.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [open, debouncedQ]);
+
+  const empty = useMemo(() => !loading && !error && items.length === 0, [loading, error, items]);
+
   if (!open) return null;
 
   return (
@@ -21,6 +56,45 @@ export default function InfoBoardModal({ open, onClose }) {
               convenio.
             </em>
           </p>
+
+          <div className="info-modal-search">
+            <input
+              type="search"
+              placeholder="Buscar…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+
+          {loading && <p className="info-modal-hint">Cargando anuncios…</p>}
+          {error && (
+            <p className="info-modal-error" role="alert">
+              {error}
+            </p>
+          )}
+          {empty && <p className="info-modal-hint">No hay anuncios activos.</p>}
+
+          <div className="info-modal-list">
+            {items.map((item) => (
+              <article key={item.id || item.titulo} className="info-modal-card">
+                <div className="info-modal-card-header">
+                  <div>
+                    <h3 className="info-modal-card-title">{item.titulo || "(Sin título)"}</h3>
+                    {item.tipo && <p className="info-modal-chip">{item.tipo}</p>}
+                  </div>
+                  <button
+                    className="info-modal-open"
+                    onClick={() => item.url && window.open(item.url, "_blank", "noopener,noreferrer")}
+                  >
+                    Abrir
+                  </button>
+                </div>
+                {item.descripcion && (
+                  <p className="info-modal-card-desc">{item.descripcion}</p>
+                )}
+              </article>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/clon/InicioBeneficiosFinalPublicado/src/services/api.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/services/api.js
@@ -67,3 +67,5 @@ export const Api = {
 
 // 🧾 Log de entorno activo
 console.log(`🌍 API activa: ${target.toUpperCase()} → ${API_BASE}`);
+
+export { API_BASE, httpGet };

--- a/clon/InicioBeneficiosFinalPublicado/src/services/infoBoardService.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/services/infoBoardService.js
@@ -1,0 +1,31 @@
+import { httpGet } from "./api";
+
+const normalize = (v) => (typeof v === "string" ? v.trim() : v ?? "");
+
+export async function getInfoBoard({ activo = true, q = "" } = {}) {
+  const params = new URLSearchParams();
+  if (activo !== undefined && activo !== null) params.set("activo", String(activo));
+  if (q) params.set("q", q.trim());
+
+  const qs = params.toString();
+  const path = `/api/InfoBoard${qs ? `?${qs}` : ""}`;
+
+  try {
+    const data = await httpGet(path);
+    if (!data) return [];
+    return Array.isArray(data) ? data : [data];
+  } catch (err) {
+    const msg = err?.message || "Error desconocido";
+    throw new Error(`No se pudo obtener la pizarra: ${msg}`);
+  }
+}
+
+export function mapInfoBoardItem(raw) {
+  return {
+    id: raw?.infoBoardItemId ?? raw?.InfoBoardItemId ?? raw?.id ?? raw?.Id,
+    titulo: normalize(raw?.titulo ?? raw?.Titulo),
+    descripcion: normalize(raw?.descripcion ?? raw?.Descripcion),
+    url: normalize(raw?.url ?? raw?.Url),
+    tipo: normalize(raw?.tipo ?? raw?.Tipo),
+  };
+}


### PR DESCRIPTION
## Summary
- connect the landing InfoBoard modal to the API with loading/error/empty states and search
- add shared InfoBoard services for both landing and admin apps
- create an admin InfoBoard CRUD screen with filters, validation, and navigation entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0682faa48322aa81b1b4eab12780)