### PR TITLE
Enhance toque analytics and benefit summaries

### DIFF
--- a/api/API/Controllers/ToqueBeneficioController.cs
+++ b/api/API/Controllers/ToqueBeneficioController.cs
@@ -32,10 +32,20 @@ namespace API.Controllers
         }
 
         [HttpGet("analytics/{beneficioId:guid}")]
-        public async Task<IActionResult> ObtenerAnalytics([FromRoute] Guid beneficioId, [FromQuery] string? range = "1W")
+        public async Task<IActionResult> ObtenerAnalytics(
+            [FromRoute] Guid beneficioId,
+            [FromQuery] string? range = "1W",
+            [FromQuery] string? granularity = null)
         {
-            var analytics = await _toqueBeneficioFlujo.ObtenerAnalytics(beneficioId, range);
+            var analytics = await _toqueBeneficioFlujo.ObtenerAnalytics(beneficioId, range, granularity);
             return Ok(analytics);
+        }
+
+        [HttpGet("resumen")]
+        public async Task<IActionResult> ObtenerResumen([FromQuery] string? range = "1W")
+        {
+            var resumen = await _toqueBeneficioFlujo.ObtenerResumen(range);
+            return Ok(resumen);
         }
     }
 }

--- a/api/Abstracciones/Interfaces/API/IToqueBeneficioController.cs
+++ b/api/Abstracciones/Interfaces/API/IToqueBeneficioController.cs
@@ -6,6 +6,7 @@ namespace Abstracciones.Interfaces.API
     public interface IToqueBeneficioController
     {
         Task<IActionResult> Registrar(ToqueBeneficioRequest request);
-        Task<IActionResult> ObtenerAnalytics(Guid beneficioId, string? range);
+        Task<IActionResult> ObtenerAnalytics(Guid beneficioId, string? range, string? granularity);
+        Task<IActionResult> ObtenerResumen(string? range);
     }
 }

--- a/api/Abstracciones/Interfaces/DA/IToqueBeneficioDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IToqueBeneficioDA.cs
@@ -5,6 +5,15 @@ namespace Abstracciones.Interfaces.DA
     public interface IToqueBeneficioDA
     {
         Task<ToqueBeneficio> Registrar(Guid beneficioId, string? origen);
-        Task<IEnumerable<ToqueBeneficioDia>> ObtenerSeries(Guid beneficioId, DateTime desde, DateTime hasta);
+        Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(
+            Guid beneficioId,
+            DateTime desde,
+            DateTime hasta,
+            string granularity,
+            DateTime prevDesde,
+            DateTime prevHasta
+        );
+
+        Task<IEnumerable<ToqueBeneficioResumen>> ObtenerResumen(DateTime desde, DateTime hasta);
     }
 }

--- a/api/Abstracciones/Interfaces/Flujo/IToqueBeneficioFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IToqueBeneficioFlujo.cs
@@ -5,6 +5,7 @@ namespace Abstracciones.Interfaces.Flujo
     public interface IToqueBeneficioFlujo
     {
         Task<ToqueBeneficio> Registrar(Guid beneficioId, string? origen);
-        Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(Guid beneficioId, string? rango);
+        Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(Guid beneficioId, string? rango, string? granularity);
+        Task<IEnumerable<ToqueBeneficioResumen>> ObtenerResumen(string? rango);
     }
 }

--- a/api/Abstracciones/Modelos/ToqueBeneficio.cs
+++ b/api/Abstracciones/Modelos/ToqueBeneficio.cs
@@ -14,16 +14,32 @@ namespace Abstracciones.Modelos
     {
         public DateTime Date { get; set; }
         public int Count { get; set; }
+        public string Label { get; set; } = string.Empty;
+        public string Iso { get; set; } = string.Empty;
     }
 
     public class ToqueBeneficioAnalyticsResponse
     {
         public Guid BeneficioId { get; set; }
         public string Range { get; set; } = string.Empty;
+        public string Granularity { get; set; } = string.Empty;
         public DateTime From { get; set; }
         public DateTime To { get; set; }
         public IEnumerable<ToqueBeneficioDia> Series { get; set; } = Enumerable.Empty<ToqueBeneficioDia>();
         public int Total { get; set; }
+        public DateTime PrevFrom { get; set; }
+        public DateTime PrevTo { get; set; }
+        public int PrevTotal { get; set; }
+        public int Delta { get; set; }
+        public double? DeltaPct { get; set; }
+        public ToqueBeneficioKpis Kpis { get; set; } = new();
+    }
+
+    public class ToqueBeneficioKpis
+    {
+        public int Today { get; set; }
+        public int Last7d { get; set; }
+        public int Ytd { get; set; }
     }
 
     public class ToqueBeneficioRequest
@@ -31,5 +47,11 @@ namespace Abstracciones.Modelos
         [Required]
         public string BeneficioId { get; set; } = string.Empty;
         public string? Origen { get; set; }
+    }
+
+    public class ToqueBeneficioResumen
+    {
+        public Guid BeneficioId { get; set; }
+        public int Count { get; set; }
     }
 }

--- a/api/DA/ToqueBeneficioDA.cs
+++ b/api/DA/ToqueBeneficioDA.cs
@@ -40,9 +40,25 @@ VALUES (@BeneficioId, SYSUTCDATETIME(), @Origen);
             };
         }
 
-        public async Task<IEnumerable<ToqueBeneficioDia>> ObtenerSeries(Guid beneficioId, DateTime desde, DateTime hasta)
+        public async Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(
+            Guid beneficioId,
+            DateTime desde,
+            DateTime hasta,
+            string granularity,
+            DateTime prevDesde,
+            DateTime prevHasta)
         {
-            const string sql = @"
+            var isMonthly = string.Equals(granularity, "MONTH", StringComparison.OrdinalIgnoreCase);
+
+            var sqlSeries = isMonthly
+                ? @"
+SELECT DATEFROMPARTS(YEAR(Fecha), MONTH(Fecha), 1) AS [Date], COUNT(*) AS [Count]
+FROM core.ToqueBeneficio
+WHERE BeneficioId = @BeneficioId AND Fecha >= @Desde AND Fecha < @Hasta
+GROUP BY YEAR(Fecha), MONTH(Fecha)
+ORDER BY [Date];
+"
+                : @"
 SELECT CAST(Fecha AS date) AS [Date], COUNT(*) AS [Count]
 FROM core.ToqueBeneficio
 WHERE BeneficioId = @BeneficioId AND Fecha >= @Desde AND Fecha < @Hasta
@@ -50,12 +66,79 @@ GROUP BY CAST(Fecha AS date)
 ORDER BY [Date];
 ";
 
-            return await _dapperWrapper.QueryAsync<ToqueBeneficioDia>(
+            const string sqlTotals = @"
+SELECT
+    SUM(CASE WHEN Fecha >= @Desde AND Fecha < @Hasta THEN 1 ELSE 0 END) AS Total,
+    SUM(CASE WHEN Fecha >= @PrevDesde AND Fecha < @PrevHasta THEN 1 ELSE 0 END) AS PrevTotal
+FROM core.ToqueBeneficio
+WHERE BeneficioId = @BeneficioId;
+";
+
+            const string sqlKpis = @"
+SELECT
+    SUM(CASE WHEN CAST(Fecha AS date) = CAST(SYSUTCDATETIME() AS date) THEN 1 ELSE 0 END) AS Today,
+    SUM(CASE WHEN Fecha >= DATEADD(day, -6, CAST(SYSUTCDATETIME() AS date)) AND Fecha < DATEADD(day, 1, CAST(SYSUTCDATETIME() AS date)) THEN 1 ELSE 0 END) AS Last7d,
+    SUM(CASE WHEN Fecha >= DATEFROMPARTS(YEAR(SYSUTCDATETIME()), 1, 1) AND Fecha < DATEADD(day, 1, CAST(SYSUTCDATETIME() AS date)) THEN 1 ELSE 0 END) AS Ytd
+FROM core.ToqueBeneficio
+WHERE BeneficioId = @BeneficioId;
+";
+
+            var seriesTask = _dapperWrapper.QueryAsync<ToqueBeneficioDia>(
                 _dbConnection,
-                sql,
+                sqlSeries,
                 new { BeneficioId = beneficioId, Desde = desde, Hasta = hasta },
                 commandType: CommandType.Text
             );
+
+            var totalsTask = _dapperWrapper.QueryFirstOrDefaultAsync<dynamic>(
+                _dbConnection,
+                sqlTotals,
+                new { BeneficioId = beneficioId, Desde = desde, Hasta = hasta, PrevDesde = prevDesde, PrevHasta = prevHasta },
+                commandType: CommandType.Text
+            );
+
+            var kpisTask = _dapperWrapper.QueryFirstOrDefaultAsync<ToqueBeneficioKpis>(
+                _dbConnection,
+                sqlKpis,
+                new { BeneficioId = beneficioId },
+                commandType: CommandType.Text
+            );
+
+            await Task.WhenAll(seriesTask, totalsTask, kpisTask);
+
+            var totals = await totalsTask ?? new { Total = 0, PrevTotal = 0 };
+
+            return new ToqueBeneficioAnalyticsResponse
+            {
+                BeneficioId = beneficioId,
+                Range = string.Empty,
+                Granularity = granularity,
+                From = desde,
+                To = hasta,
+                Series = await seriesTask,
+                Total = (int)(totals.Total ?? 0),
+                PrevFrom = prevDesde,
+                PrevTo = prevHasta,
+                PrevTotal = (int)(totals.PrevTotal ?? 0),
+                Kpis = await kpisTask ?? new ToqueBeneficioKpis()
+            };
+        }
+
+        public async Task<IEnumerable<ToqueBeneficioResumen>> ObtenerResumen(DateTime desde, DateTime hasta)
+        {
+            const string sql = @"
+SELECT BeneficioId, COUNT(*) AS [Count]
+FROM core.ToqueBeneficio
+WHERE Fecha >= @Desde AND Fecha < @Hasta
+GROUP BY BeneficioId;
+";
+
+            return await _dapperWrapper.QueryAsync<ToqueBeneficioResumen>(
+              _dbConnection,
+              sql,
+              new { Desde = desde, Hasta = hasta },
+              commandType: CommandType.Text
+          );
         }
     }
 }

--- a/api/Flujo/ToqueBeneficioFlujo.cs
+++ b/api/Flujo/ToqueBeneficioFlujo.cs
@@ -19,31 +19,54 @@ namespace Flujo
             return await _toqueBeneficioDA.Registrar(beneficioId, origen);
         }
 
-        public async Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(Guid beneficioId, string? rango)
+        public async Task<ToqueBeneficioAnalyticsResponse> ObtenerAnalytics(Guid beneficioId, string? rango, string? granularity)
         {
             var today = DateTime.UtcNow.Date;
             var normalizedRange = NormalizarRango(rango);
+            var normalizedGranularity = NormalizarGranularidad(granularity, normalizedRange);
+            var (desde, hasta) = CalcularVentana(normalizedRange, today);
+            var (prevDesde, prevHasta) = CalcularVentanaPrevia(normalizedRange, desde, hasta, today);
 
-            var (desde, hasta) = normalizedRange switch
-            {
-                "1M" => (today.AddDays(-29), today),
-                "YTD" => (new DateTime(today.Year, 1, 1), today),
-                _ => (today.AddDays(-6), today)
-            };
+            var analytics = await _toqueBeneficioDA.ObtenerAnalytics(
+                beneficioId,
+                desde,
+                hasta.AddDays(1),
+                normalizedGranularity,
+                prevDesde,
+                prevHasta.AddDays(1));
 
-            // Hasta es exclusivo en la consulta para incluir el día completo
-            var series = await _toqueBeneficioDA.ObtenerSeries(beneficioId, desde, hasta.AddDays(1));
-            var seriesNormalizada = NormalizarSeries(series, desde, hasta);
+            var series = TransformarSeries(analytics.Series, normalizedGranularity);
+
+            var delta = analytics.Total - analytics.PrevTotal;
+            var deltaPct = analytics.PrevTotal == 0
+                ? (double?)null
+                : Math.Round((double)delta / analytics.PrevTotal * 100, 2);
 
             return new ToqueBeneficioAnalyticsResponse
             {
                 BeneficioId = beneficioId,
                 Range = normalizedRange,
+                Granularity = normalizedGranularity,
                 From = desde,
                 To = hasta,
-                Series = seriesNormalizada,
-                Total = seriesNormalizada.Sum(s => s.Count)
+                PrevFrom = prevDesde,
+                PrevTo = prevHasta,
+                PrevTotal = analytics.PrevTotal,
+                Series = series,
+                Total = analytics.Total,
+                Delta = delta,
+                DeltaPct = deltaPct,
+                Kpis = analytics.Kpis
             };
+        }
+
+        public async Task<IEnumerable<ToqueBeneficioResumen>> ObtenerResumen(string? rango)
+        {
+            var today = DateTime.UtcNow.Date;
+            var normalizedRange = NormalizarRango(rango);
+            var (desde, hasta) = CalcularVentana(normalizedRange, today);
+
+            return await _toqueBeneficioDA.ObtenerResumen(desde, hasta.AddDays(1));
         }
 
         private static string NormalizarRango(string? rango)
@@ -53,19 +76,73 @@ namespace Flujo
                 : rango.Trim().ToUpperInvariant();
         }
 
-        private static IEnumerable<ToqueBeneficioDia> NormalizarSeries(IEnumerable<ToqueBeneficioDia> series, DateTime desde, DateTime hasta)
+        private static string NormalizarGranularidad(string? granularidad, string rango)
         {
-            var porDia = series.ToDictionary(s => s.Date.Date, s => s.Count);
-            var cursor = desde.Date;
-            while (cursor <= hasta.Date)
+            if (!string.IsNullOrWhiteSpace(granularidad))
+            {
+                var g = granularidad.Trim().ToUpperInvariant();
+                if (g is "DAY" or "MONTH") return g;
+            }
+
+            return rango switch
+            {
+                "YTD" => "MONTH",
+                "1M" => "DAY",
+                _ => "DAY",
+            };
+        }
+
+        private static (DateTime desde, DateTime hasta) CalcularVentana(string rango, DateTime today)
+        {
+            return rango switch
+            {
+                "1M" => (today.AddDays(-29), today),
+                "YTD" => (new DateTime(today.Year, 1, 1), today),
+                _ => (today.AddDays(-6), today)
+            };
+        }
+
+        private static (DateTime desde, DateTime hasta) CalcularVentanaPrevia(string rango, DateTime desde, DateTime hasta, DateTime today)
+        {
+            return rango switch
+            {
+                "1M" => (desde.AddDays(-30), hasta.AddDays(-30)),
+                "YTD" => CalcularVentanaAnteriorYtd(today),
+                _ => (desde.AddDays(-7), hasta.AddDays(-7))
+            };
+        }
+
+        private static (DateTime desde, DateTime hasta) CalcularVentanaAnteriorYtd(DateTime today)
+        {
+            var previousYear = today.Year - 1;
+            if (previousYear < DateTime.MinValue.Year)
+            {
+                return (today, today);
+            }
+
+            var prevDesde = new DateTime(previousYear, 1, 1);
+            var prevHasta = new DateTime(previousYear, 12, 31);
+            return (prevDesde, prevHasta);
+        }
+
+        private static IEnumerable<ToqueBeneficioDia> TransformarSeries(IEnumerable<ToqueBeneficioDia> series, string granularity)
+        {
+            var ordered = series
+                .Where(s => s.Date != default)
+                .OrderBy(s => s.Date)
+                .ToList();
+
+            foreach (var punto in ordered)
             {
                 yield return new ToqueBeneficioDia
                 {
-                    Date = cursor,
-                    Count = porDia.TryGetValue(cursor, out var count) ? count : 0
+                    Date = punto.Date,
+                    Count = punto.Count,
+                    Iso = punto.Date.ToString("yyyy-MM-dd"),
+                    Label = granularity == "MONTH"
+                        ? punto.Date.ToString("yyyy-MM")
+                        : punto.Date.ToString("MM-dd")
                 };
-
-                cursor = cursor.AddDays(1);
             }
         }
     }

--- a/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
@@ -54,6 +54,11 @@ export const BeneficioImagenApi = {
 };
 
 export const ToqueBeneficioApi = {
-  analytics: (beneficioId, range = "1W", o = {}) =>
-    req(`/api/ToqueBeneficio/analytics/${beneficioId}?range=${range}`, o),
+  analytics: (beneficioId, range = "1W", o = {}, granularity) => {
+    const params = new URLSearchParams({ range });
+    if (granularity) params.set("granularity", granularity);
+    return req(`/api/ToqueBeneficio/analytics/${beneficioId}?${params.toString()}`, o);
+  },
+  resumen: (range = "1W", o = {}) =>
+    req(`/api/ToqueBeneficio/resumen?range=${range}`, o),
 };

--- a/clon/BeneficiosFinalPublicado/src/components/BenefitCard.jsx
+++ b/clon/BeneficiosFinalPublicado/src/components/BenefitCard.jsx
@@ -20,6 +20,14 @@ export default function BenefitCard({ item, onClick }) {
     }
   };
 
+  const registrarToqueUnico = async (event) => {
+    if (event?.nativeEvent) {
+      if (event.nativeEvent.__toqueRegistrado) return;
+      event.nativeEvent.__toqueRegistrado = true;
+    }
+    await registrarToque();
+  };
+
   useEffect(() => {
     if (!ref.current) return;
     if (imgSrc && imgSrc !== EMBED_PLACEHOLDER) return;
@@ -58,7 +66,12 @@ export default function BenefitCard({ item, onClick }) {
   }, [item, imgSrc]);
 
   const handleClick = (event) => {
-    registrarToque();
+    onClick?.(event);
+  };
+
+  const handleInnerAction = (event) => {
+    event?.stopPropagation?.();
+    registrarToqueUnico(event);
     onClick?.(event);
   };
 
@@ -67,6 +80,7 @@ export default function BenefitCard({ item, onClick }) {
       ref={ref}
       className="rounded-2xl bg-neutral-900 border border-white/10 p-3 cursor-pointer hover:bg-white/5 transition"
       onClick={handleClick}
+      onClickCapture={registrarToqueUnico}
     >
       {/* Imagen + badges */}
       <div className="w-full aspect-[4/3] rounded-xl bg-white/10 overflow-hidden relative">
@@ -87,9 +101,13 @@ export default function BenefitCard({ item, onClick }) {
 
         {/* Descuento (si existe) */}
         {item.descuento && (
-          <span className="absolute right-2 top-2 rounded-full bg-emerald-500 text-black text-[11px] px-2 py-0.5 font-semibold">
+          <button
+            type="button"
+            className="absolute right-2 top-2 rounded-full bg-emerald-500 text-black text-[11px] px-2 py-0.5 font-semibold"
+            onClick={handleInnerAction}
+          >
             {item.descuento}
-          </span>
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- expand toque analytics to include granularity, KPI totals, previous-period comparison, and a list-level resumen endpoint
- update the admin dashboard to display KPI cards, refined bar visuals, previous-period deltas, and range-aware touch counts in the list
- prevent double-counting toque registrations from public benefit cards while preserving CTA behavior

## Testing
- `dotnet build HR-Beneficios-API.sln` *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f23b1a86c83229db4b8400156ddfb)