### PR TITLE
Switch RifaParticipacion IDs to GUID and add toast notification

### DIFF
--- a/api/API/Controllers/RifaParticipacionController.cs
+++ b/api/API/Controllers/RifaParticipacionController.cs
@@ -2,6 +2,7 @@ using Abstracciones.Interfaces.API;
 using Abstracciones.Interfaces.Flujo;
 using Abstracciones.Modelos;
 using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace API.Controllers
 {
@@ -21,7 +22,7 @@ namespace API.Controllers
     /// 
     /// Respuesta 201:
     /// {
-    ///   "id": 1,
+    ///   "id": "c2e8ecab-0d7f-4f36-9fa9-3f5ff3e5c001",
     ///   "nombre": "Ana Pérez",
     ///   "correo": "ana@example.com",
     ///   "telefono": "+50688888888",
@@ -75,17 +76,19 @@ namespace API.Controllers
             return Ok(result);
         }
 
-        [HttpGet("{id:int}")]
-        public async Task<IActionResult> Obtener(int id)
+        [HttpGet("{id:guid}")]
+        public async Task<IActionResult> Obtener(Guid id)
         {
+            if (id == Guid.Empty) return BadRequest("Id inválido");
             var item = await _flujo.Obtener(id);
-            return item is null || item.Id == 0 ? NotFound() : Ok(item);
+            return item is null || item.Id == Guid.Empty ? NotFound() : Ok(item);
         }
 
-        [HttpPut("{id:int}/estado")]
-        public async Task<IActionResult> ActualizarEstado(int id, [FromBody] RifaParticipacionEstadoRequest body)
+        [HttpPut("{id:guid}/estado")]
+        public async Task<IActionResult> ActualizarEstado(Guid id, [FromBody] RifaParticipacionEstadoRequest body)
         {
             if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            if (id == Guid.Empty) return BadRequest("Id inválido");
             var actualizado = await _flujo.ActualizarEstado(id, body.Estado);
             if (!actualizado) return NotFound();
 

--- a/api/Abstracciones/Interfaces/API/IRifaParticipacionController.cs
+++ b/api/Abstracciones/Interfaces/API/IRifaParticipacionController.cs
@@ -1,5 +1,6 @@
 using Abstracciones.Modelos;
 using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Abstracciones.Interfaces.API
 {
@@ -13,7 +14,7 @@ namespace Abstracciones.Interfaces.API
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 20,
             [FromQuery] string? sort = null);
-        Task<IActionResult> Obtener([FromRoute] int id);
-        Task<IActionResult> ActualizarEstado([FromRoute] int id, [FromBody] RifaParticipacionEstadoRequest body);
+        Task<IActionResult> Obtener([FromRoute] Guid id);
+        Task<IActionResult> ActualizarEstado([FromRoute] Guid id, [FromBody] RifaParticipacionEstadoRequest body);
     }
 }

--- a/api/Abstracciones/Interfaces/DA/IRifaParticipacionDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IRifaParticipacionDA.cs
@@ -1,12 +1,13 @@
+using System;
 using Abstracciones.Modelos;
 
 namespace Abstracciones.Interfaces.DA
 {
     public interface IRifaParticipacionDA
     {
-        Task<int> Crear(RifaParticipacionRequest request);     // core.RifaParticipacion_Insertar
-        Task<RifaParticipacionResponse?> Obtener(int id);       // core.RifaParticipacion_ObtenerPorId
+        Task<Guid> Crear(RifaParticipacionRequest request);     // core.RifaParticipacion_Insertar
+        Task<RifaParticipacionResponse?> Obtener(Guid id);      // core.RifaParticipacion_ObtenerPorId
         Task<IEnumerable<RifaParticipacionListado>> Listar(RifaParticipacionFiltro filtro); // core.RifaParticipacion_Listar
-        Task<bool> ActualizarEstado(int id, string estado);     // core.RifaParticipacion_ActualizarEstado
+        Task<bool> ActualizarEstado(Guid id, string estado);    // core.RifaParticipacion_ActualizarEstado
     }
 }

--- a/api/Abstracciones/Interfaces/Flujo/IRifaParticipacionFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IRifaParticipacionFlujo.cs
@@ -1,12 +1,13 @@
+using System;
 using Abstracciones.Modelos;
 
 namespace Abstracciones.Interfaces.Flujo
 {
     public interface IRifaParticipacionFlujo
     {
-        Task<int> Crear(RifaParticipacionRequest request);
-        Task<RifaParticipacionResponse?> Obtener(int id);
+        Task<Guid> Crear(RifaParticipacionRequest request);
+        Task<RifaParticipacionResponse?> Obtener(Guid id);
         Task<PagedResult<RifaParticipacionResponse>> Listar(RifaParticipacionFiltro filtro);
-        Task<bool> ActualizarEstado(int id, string estado);
+        Task<bool> ActualizarEstado(Guid id, string estado);
     }
 }

--- a/api/Abstracciones/Modelos/RifaParticipacion.cs
+++ b/api/Abstracciones/Modelos/RifaParticipacion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Abstracciones.Modelos
@@ -25,7 +26,7 @@ namespace Abstracciones.Modelos
 
     public class RifaParticipacionResponse : RifaParticipacionBase
     {
-        public int Id { get; set; }
+        public Guid Id { get; set; }
 
         [Required, StringLength(30)]
         public string Estado { get; set; } = "Nuevo";

--- a/api/BD/core/Stored Procedures/RifaParticipacion_ActualizarEstado.sql
+++ b/api/BD/core/Stored Procedures/RifaParticipacion_ActualizarEstado.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE core.RifaParticipacion_ActualizarEstado
-    @Id INT,
+    @Id UNIQUEIDENTIFIER,
     @Estado NVARCHAR(30)
 AS
 BEGIN

--- a/api/BD/core/Stored Procedures/RifaParticipacion_ObtenerPorId.sql
+++ b/api/BD/core/Stored Procedures/RifaParticipacion_ObtenerPorId.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE core.RifaParticipacion_ObtenerPorId
-    @Id INT
+    @Id UNIQUEIDENTIFIER
 AS
 BEGIN
     SET NOCOUNT ON;

--- a/api/BD/core/Tables/RifaParticipacion.sql
+++ b/api/BD/core/Tables/RifaParticipacion.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [core].[RifaParticipacion]
 (
-    [Id]             INT IDENTITY(1,1)            NOT NULL,
+    [Id]             UNIQUEIDENTIFIER CONSTRAINT [DF_RifaParticipacion_Id] DEFAULT (NEWSEQUENTIALID()) NOT NULL,
     [Nombre]         NVARCHAR(150)                NOT NULL,
     [Correo]         NVARCHAR(200)                NOT NULL,
     [Telefono]       NVARCHAR(30)                 NULL,

--- a/api/DA/RifaParticipacionDA.cs
+++ b/api/DA/RifaParticipacionDA.cs
@@ -1,5 +1,6 @@
 using Abstracciones.Interfaces.DA;
 using Abstracciones.Modelos;
+using System;
 using System.Data;
 using System.Linq;
 
@@ -16,10 +17,10 @@ namespace DA
             _dapperWrapper = dapperWrapper;
         }
 
-        public async Task<int> Crear(RifaParticipacionRequest request)
+        public async Task<Guid> Crear(RifaParticipacionRequest request)
         {
             const string sp = "core.RifaParticipacion_Insertar";
-            return await _dapperWrapper.ExecuteScalarAsync<int>(_dbConnection, sp, new
+            return await _dapperWrapper.ExecuteScalarAsync<Guid>(_dbConnection, sp, new
             {
                 request.Nombre,
                 request.Correo,
@@ -29,7 +30,7 @@ namespace DA
             }, commandType: CommandType.StoredProcedure);
         }
 
-        public async Task<RifaParticipacionResponse?> Obtener(int id)
+        public async Task<RifaParticipacionResponse?> Obtener(Guid id)
         {
             const string sp = "core.RifaParticipacion_ObtenerPorId";
             return await _dapperWrapper.QueryFirstOrDefaultAsync<RifaParticipacionResponse>(_dbConnection, sp, new { Id = id }, commandType: CommandType.StoredProcedure);
@@ -50,7 +51,7 @@ namespace DA
             }, commandType: CommandType.StoredProcedure);
         }
 
-        public async Task<bool> ActualizarEstado(int id, string estado)
+        public async Task<bool> ActualizarEstado(Guid id, string estado)
         {
             const string sp = "core.RifaParticipacion_ActualizarEstado";
             var affected = await _dapperWrapper.ExecuteAsync(_dbConnection, sp, new { Id = id, Estado = estado }, commandType: CommandType.StoredProcedure);

--- a/api/Flujo/RifaParticipacionFlujo.cs
+++ b/api/Flujo/RifaParticipacionFlujo.cs
@@ -1,6 +1,7 @@
 using Abstracciones.Interfaces.DA;
 using Abstracciones.Interfaces.Flujo;
 using Abstracciones.Modelos;
+using System;
 
 namespace Flujo
 {
@@ -18,7 +19,7 @@ namespace Flujo
             _rifaParticipacionDA = rifaParticipacionDA ?? throw new ArgumentNullException(nameof(rifaParticipacionDA));
         }
 
-        public async Task<int> Crear(RifaParticipacionRequest request)
+        public async Task<Guid> Crear(RifaParticipacionRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.Source))
             {
@@ -33,7 +34,7 @@ namespace Flujo
             return await _rifaParticipacionDA.Crear(request);
         }
 
-        public async Task<RifaParticipacionResponse?> Obtener(int id)
+        public async Task<RifaParticipacionResponse?> Obtener(Guid id)
         {
             return await _rifaParticipacionDA.Obtener(id);
         }
@@ -70,7 +71,7 @@ namespace Flujo
             };
         }
 
-        public async Task<bool> ActualizarEstado(int id, string estado)
+        public async Task<bool> ActualizarEstado(Guid id, string estado)
         {
             return await _rifaParticipacionDA.ActualizarEstado(id, estado);
         }

--- a/clon/BeneficiosFinalPublicado/src/components/FormModal.jsx
+++ b/clon/BeneficiosFinalPublicado/src/components/FormModal.jsx
@@ -1,6 +1,7 @@
 // src/components/FormModal.jsx
 import { useEffect, useRef, useState } from "react";
 import { Api } from "../services/api";
+import Toast from "./ui/Toast";
 
 export default function FormModal({
   isOpen,
@@ -16,7 +17,10 @@ export default function FormModal({
   const [form, setForm] = useState(defaultValues);
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
+  const [toastOpen, setToastOpen] = useState(false);
   const firstInputRef = useRef(null);
+
+  const successMessage = "¡Participación registrada!\nYa estás participando en la rifa 🎉";
 
   // Abrir: reset, bloquear scroll, autofocus
   useEffect(() => {
@@ -76,117 +80,125 @@ export default function FormModal({
       };
       const data = await Api.rifaParticipacion.crear(payload);
       onSubmitted?.(data);
-      alert("¡Listo! Ya estás participando.");
+      setToastOpen(true);
       onClose?.();
       setForm({ ...defaultValues });
     } catch (err) {
-      alert("No se pudo registrar tu participación. Intentá de nuevo.");
-      setErrors(s => ({ ...s, _server: err?.message }));
+      setErrors(s => ({ ...s, _server: "No se pudo registrar tu participación. Intentá de nuevo." }));
     } finally {
       setSubmitting(false);
     }
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div
-      aria-modal="true"
-      role="dialog"
-      className="fixed inset-0 z-[1000] flex items-center justify-center"
-      style={{ background: "rgba(0,0,0,0.6)" }}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose?.();  // clic en overlay cierra
-      }}
-    >
-      <form
-        onSubmit={handleSubmit}
-        className="w-[90vw] max-w-[520px] rounded-xl bg-white p-5 text-slate-900 shadow-2xl"
-        onMouseDown={(e) => e.stopPropagation()} // evita cierre por burbujeo
-      >
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-black">Participar en rifa</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Cerrar"
-            className="rounded p-2 text-black/70 hover:bg-black/5"
+    <>
+      {isOpen && (
+        <div
+          aria-modal="true"
+          role="dialog"
+          className="fixed inset-0 z-[1000] flex items-center justify-center"
+          style={{ background: "rgba(0,0,0,0.6)" }}
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) onClose?.();  // clic en overlay cierra
+          }}
+        >
+          <form
+            onSubmit={handleSubmit}
+            className="w-[90vw] max-w-[520px] rounded-xl bg-white p-5 text-slate-900 shadow-2xl"
+            onMouseDown={(e) => e.stopPropagation()} // evita cierre por burbujeo
           >
-            ✕
-          </button>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-black">Participar en rifa</h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Cerrar"
+                className="rounded p-2 text-black/70 hover:bg-black/5"
+              >
+                ✕
+              </button>
+            </div>
+
+            {errors._server && (
+              <div className="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+                {errors._server}
+              </div>
+            )}
+
+            <div className="grid gap-3">
+              <label className="grid gap-1">
+                <span className="text-sm text-black/80">Nombre completo</span>
+                <input
+                  ref={firstInputRef}
+                  className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
+                  value={form.nombre}
+                  onChange={(e) => handleChange("nombre", e.target.value)}
+                />
+                {errors.nombre && <small className="text-red-600">{errors.nombre}</small>}
+              </label>
+
+              <label className="grid gap-1">
+                <span className="text-sm text-black/80">Correo electrónico</span>
+                <input
+                  className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
+                  placeholder="nombre@dominio.com"
+                  value={form.correo}
+                  onChange={(e) => handleChange("correo", e.target.value)}
+                  inputMode="email"
+                />
+                {errors.correo && <small className="text-red-600">{errors.correo}</small>}
+              </label>
+
+              <label className="grid gap-1">
+                <span className="text-sm text-black/80">Teléfono (opcional)</span>
+                <input
+                  className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
+                  placeholder="+506 8888 8888"
+                  value={form.telefono}
+                  onChange={(e) => handleChange("telefono", e.target.value)}
+                  inputMode="tel"
+                />
+                {errors.telefono && <small className="text-red-600">{errors.telefono}</small>}
+              </label>
+
+              <label className="grid gap-1">
+                <span className="text-sm text-black/80">Mensaje (opcional)</span>
+                <textarea
+                  className="min-h-[96px] rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
+                  placeholder="Contanos cómo te ayudamos…"
+                  value={form.mensaje}
+                  onChange={(e) => handleChange("mensaje", e.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded border px-4 py-2 text-black hover:bg-black/5"
+                disabled={submitting}
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+                disabled={submitting}
+              >
+                {submitting ? "Enviando…" : "Participar"}
+              </button>
+            </div>
+          </form>
         </div>
+      )}
 
-        {errors._server && (
-          <div className="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {errors._server}
-          </div>
-        )}
-
-        <div className="grid gap-3">
-          <label className="grid gap-1">
-            <span className="text-sm text-black/80">Nombre completo</span>
-            <input
-              ref={firstInputRef}
-              className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
-              value={form.nombre}
-              onChange={(e) => handleChange("nombre", e.target.value)}
-            />
-            {errors.nombre && <small className="text-red-600">{errors.nombre}</small>}
-          </label>
-
-          <label className="grid gap-1">
-            <span className="text-sm text-black/80">Correo electrónico</span>
-            <input
-              className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
-              placeholder="nombre@dominio.com"
-              value={form.correo}
-              onChange={(e) => handleChange("correo", e.target.value)}
-              inputMode="email"
-            />
-            {errors.correo && <small className="text-red-600">{errors.correo}</small>}
-          </label>
-
-          <label className="grid gap-1">
-            <span className="text-sm text-black/80">Teléfono (opcional)</span>
-            <input
-              className="rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
-              placeholder="+506 8888 8888"
-              value={form.telefono}
-              onChange={(e) => handleChange("telefono", e.target.value)}
-              inputMode="tel"
-            />
-            {errors.telefono && <small className="text-red-600">{errors.telefono}</small>}
-          </label>
-
-          <label className="grid gap-1">
-            <span className="text-sm text-black/80">Mensaje (opcional)</span>
-            <textarea
-              className="min-h-[96px] rounded border px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:text-slate-900 focus:placeholder:text-slate-500 disabled:text-slate-500 disabled:placeholder:text-slate-400"
-              placeholder="Contanos cómo te ayudamos…"
-              value={form.mensaje}
-              onChange={(e) => handleChange("mensaje", e.target.value)}
-            />
-          </label>
-        </div>
-
-        <div className="mt-5 flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded border px-4 py-2 text-black hover:bg-black/5"
-            disabled={submitting}
-          >
-            Cancelar
-          </button>
-          <button
-            type="submit"
-            className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
-            disabled={submitting}
-          >
-            {submitting ? "Enviando…" : "Participar"}
-          </button>
-        </div>
-      </form>
-    </div>
+      <Toast
+        open={toastOpen}
+        message={successMessage}
+        duration={3600}
+        onClose={() => setToastOpen(false)}
+      />
+    </>
   );
 }

--- a/clon/BeneficiosFinalPublicado/src/components/ui/Toast.jsx
+++ b/clon/BeneficiosFinalPublicado/src/components/ui/Toast.jsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+export default function Toast({ open, message, duration = 3500, onClose }) {
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => onClose?.(), duration);
+    return () => clearTimeout(t);
+  }, [open, duration, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed left-1/2 top-4 z-[1100] -translate-x-1/2 md:left-auto md:right-6 md:translate-x-0"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="pointer-events-auto flex max-w-sm items-start gap-3 rounded-lg bg-emerald-700 px-4 py-3 text-white shadow-xl shadow-emerald-900/30">
+        <span className="text-xl" aria-hidden>
+          ✓
+        </span>
+        <div className="text-sm leading-snug">
+          {message.split("\n").map((line, idx) => (
+            <p key={idx}>{line}</p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace browser alerts in the raffle participation modal with a styled toast notification that auto-dismisses and closes the modal
- change the RifaParticipacion table and stored procedures to use UNIQUEIDENTIFIER with sequential defaults
- update API, flow, and data access layers to accept/return GUID IDs for raffle participations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8cfb855c8322b13608a24e7066e2)