### PR TITLE
Implement badge token login for providers

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/App.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/App.jsx
@@ -27,7 +27,8 @@ function useStoredSession(key) {
 
 function RequireProviderSession({ children }) {
   const session = useStoredSession("hr_proveedor_session");
-  if (!session?.proveedorId) return <Navigate to="/login" replace />;
+  if (!session?.proveedorId || !session?.token)
+    return <Navigate to="/login" replace />;
   return children;
 }
 

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/ProveedoresPage.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/ProveedoresPage.jsx
@@ -1,10 +1,12 @@
 // src/components/AdminShell/pages/ProveedoresPage.jsx
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ProveedorApi } from "../../../services/adminApi";
+import { buildBadgeLink, generateAccessToken } from "../../../utils/badge";
 
 const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const norm = (v) => (v == null ? "" : String(v).trim());
 const getProvId = (p) => norm(p?.proveedorId ?? p?.id ?? p?.ProveedorId ?? p?.ID);
+const getToken = (p) => norm(p?.accessToken);
 const guid = () =>
   crypto.randomUUID?.() ||
   "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -22,38 +24,47 @@ export default function ProveedoresPage({ provs = [], addProveedor, onProveedorU
     const origin = typeof window !== "undefined" ? window.location.origin : "";
     return provs.map((p) => {
       const proveedorId = getProvId(p);
-      const link = proveedorId ? `${origin}/login?proveedorId=${proveedorId}` : "";
-      return { ...p, proveedorId, link };
+      const accessToken = getToken(p);
+      const link = buildBadgeLink(origin, accessToken);
+      return { ...p, proveedorId, accessToken, link };
     });
   }, [provs]);
 
   useEffect(() => {
     for (const p of provs) {
       const pid = getProvId(p);
-      if (GUID_RE.test(pid) || attempted.current.has(pid || p?.nombre)) continue;
+      const token = getToken(p);
+      if ((GUID_RE.test(pid) && token) || attempted.current.has(pid || p?.nombre))
+        continue;
       attempted.current.add(pid || p?.nombre || Math.random().toString());
-      assignGuid(p).catch((err) => {
-        console.error("No se pudo asignar GUID", err);
-        setError("No se pudo generar un ID para algunos proveedores.");
+      ensureBadge(p).catch((err) => {
+        console.error("No se pudo preparar badge", err);
+        setError("No se pudo generar un badge para algunos proveedores.");
       });
     }
   }, [provs]);
 
-  const assignGuid = async (prov) => {
+  const ensureBadge = async (prov, { regenerateToken = false } = {}) => {
     const apiId = getProvId(prov) || prov?.id;
     if (!apiId) return;
-    const nuevoGuid = guid();
+    const existingId = getProvId(prov);
+    const nuevoGuid = GUID_RE.test(existingId) ? existingId : guid();
+    const nuevoToken = regenerateToken || !getToken(prov)
+      ? generateAccessToken()
+      : getToken(prov);
     setProcessing((s) => ({ ...s, [apiId]: true }));
     try {
       await ProveedorApi.update(apiId, {
         nombre: prov?.nombre ?? prov?.Nombre ?? "",
         proveedorId: nuevoGuid,
+        accessToken: nuevoToken,
       });
       const fresh = await ProveedorApi.get(apiId);
       const normalized = {
         ...fresh,
         id: getProvId(fresh) || apiId,
         proveedorId: getProvId(fresh) || nuevoGuid,
+        accessToken: getToken(fresh) || nuevoToken,
         nombre: fresh?.nombre ?? prov?.nombre ?? prov?.Nombre,
       };
       onProveedorUpdated?.(normalized);
@@ -74,6 +85,11 @@ export default function ProveedoresPage({ provs = [], addProveedor, onProveedorU
     } catch (err) {
       console.error("No se pudo copiar", err);
     }
+  };
+
+  const handleRegenerate = async (prov) => {
+    if (!prov) return;
+    await ensureBadge(prov, { regenerateToken: true });
   };
 
   return (
@@ -98,19 +114,31 @@ export default function ProveedoresPage({ provs = [], addProveedor, onProveedorU
             className="rounded-2xl border border-white/10 bg-black/40 p-4 space-y-3"
           >
             <div className="flex items-start justify-between gap-3">
-              <div>
+              <div className="space-y-1">
                 <p className="text-sm font-semibold">{p.nombre ?? p.Nombre}</p>
-                <p className="text-[11px] text-white/50 break-all">
-                  {p.proveedorId || "Asignando GUID..."}
+                <p className="text-[11px] text-white/60 break-all">
+                  ID: {p.proveedorId || "Asignando ID..."}
+                </p>
+                <p className="text-[11px] text-white/60 break-all">
+                  Badge: {p.accessToken || "Generando badge..."}
                 </p>
               </div>
-              <button
-                className="px-2 py-1 rounded-full text-[11px] bg-white/5 hover:bg-white/10"
-                onClick={() => handleCopy(p.link)}
-                disabled={!p.link}
-              >
-                Copiar link
-              </button>
+              <div className="flex flex-col gap-1 items-end">
+                <button
+                  className="px-2 py-1 rounded-full text-[11px] bg-white/5 hover:bg-white/10 disabled:opacity-50"
+                  onClick={() => handleCopy(p.link)}
+                  disabled={!p.link}
+                >
+                  Copiar link
+                </button>
+                <button
+                  className="px-2 py-1 rounded-full text-[11px] bg-white/5 hover:bg-white/10 disabled:opacity-50"
+                  onClick={() => handleRegenerate(p)}
+                  disabled={processing[getProvId(p)]}
+                >
+                  Regenerar badge
+                </button>
+              </div>
             </div>
 
             <div className="bg-white/5 rounded-xl p-2 grid place-items-center">
@@ -122,7 +150,7 @@ export default function ProveedoresPage({ provs = [], addProveedor, onProveedorU
                 />
               ) : (
                 <p className="text-xs text-white/60">
-                  {processing[getProvId(p)] ? "Generando QR..." : "Sin identificador"}
+                  {processing[getProvId(p)] ? "Generando badge..." : "Sin identificador"}
                 </p>
               )}
             </div>

--- a/clon/AdminBeneficiosFinalPublicado/src/hooks/useCatalogos.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/hooks/useCatalogos.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { CategoriaApi, ProveedorApi } from "../services/adminApi";
+import { generateAccessToken } from "../utils/badge";
 
 // helpers arriba del hook
 const norm   = (v) => (v == null ? "" : String(v).trim());
@@ -10,6 +11,7 @@ const getCatId  = (r) => normId(
   r?.categoria?.id ?? r?.categoria?.Id
 );
 const getProvId = (p) => normId(p?.id ?? p?.proveedorId ?? p?.ProveedorId ?? p?.ID);
+const getToken = (p) => normId(p?.accessToken ?? "");
 
 const dedupeById = (arr, getId) => {
   const seen = new Set();
@@ -55,8 +57,9 @@ export function useCatalogos() {
           .map(p => {
             const id = getProvId(p);
             const nombre = norm(p?.nombre ?? p?.Nombre ?? p?.titulo ?? p?.Titulo);
+            const accessToken = getToken(p);
             if (!id || !nombre) return null;
-            return { ...p, id, proveedorId: id, nombre };
+            return { ...p, id, proveedorId: id, nombre, accessToken };
           })
           .filter(Boolean);
         const P = dedupeById(P1, getProvId);
@@ -154,14 +157,16 @@ const getCatId = (r) => {
     const nombre = norm(v);
     if (!nombre) return;
 
-    const idOrObj = await ProveedorApi.create({ nombre });
+    const accessToken = generateAccessToken();
+    const idOrObj = await ProveedorApi.create({ nombre, accessToken });
     const id = typeof idOrObj === "string" ? idOrObj : getProvId(idOrObj);
     const createdRaw = id ? await ProveedorApi.get(id) : idOrObj;
 
     const nodo = (() => {
       const rid = getProvId(createdRaw) || normId(id);
       const nom = norm(createdRaw?.nombre ?? nombre);
-      return { ...createdRaw, id: rid, proveedorId: rid, nombre: nom };
+      const badge = getToken(createdRaw) || accessToken;
+      return { ...createdRaw, id: rid, proveedorId: rid, nombre: nom, accessToken: badge };
     })();
 
     setProvs(s => dedupeById([nodo, ...s], getProvId));
@@ -183,6 +188,7 @@ const getCatId = (r) => {
       id,
       proveedorId: id,
       nombre: norm(fresh?.nombre ?? nombre),
+      accessToken: getToken(fresh) || getToken(r),
     };
 
     setProvs(s => s.map(x => (getProvId(x) === id ? nodo : x)));
@@ -198,7 +204,12 @@ const getCatId = (r) => {
 
   const upsertProveedorLocal = (prov) => {
     if (!prov) return;
-    setProvs((s) => dedupeById([prov, ...s], getProvId));
+    const enriched = {
+      ...prov,
+      proveedorId: getProvId(prov),
+      accessToken: getToken(prov),
+    };
+    setProvs((s) => dedupeById([enriched, ...s], getProvId));
   };
 
   return {

--- a/clon/AdminBeneficiosFinalPublicado/src/pages/ProviderPortal.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/pages/ProviderPortal.jsx
@@ -60,7 +60,7 @@ export default function ProviderPortal() {
             Portal de proveedor
           </p>
           <h1 className="text-2xl font-semibold">
-            {session?.nombre || "Proveedor"}
+            {session?.proveedorNombre || session?.nombre || "Proveedor"}
           </h1>
         </div>
         <button

--- a/clon/AdminBeneficiosFinalPublicado/src/utils/badge.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/utils/badge.js
@@ -1,0 +1,17 @@
+export function generateAccessToken(byteLength = 32) {
+  try {
+    const bytes = new Uint8Array(byteLength);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  } catch (err) {
+    console.warn("No se pudo usar getRandomValues, usando generador inseguro", err);
+    let fallback = "";
+    for (let i = 0; i < byteLength * 2; i += 1) {
+      fallback += Math.floor(Math.random() * 16).toString(16);
+    }
+    return fallback;
+  }
+}
+
+export const buildBadgeLink = (origin, token) =>
+  token ? `${origin}/login?token=${token}` : "";


### PR DESCRIPTION
## Summary
- add badge token generation utilities and surface QR links for provider badges
- update provider login flow to validate access tokens and persist session details
- ensure provider portal gating and admin provider management handle badge regeneration

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694031d682e08322b96ab703d0ac4688)