### PR TITLE
Add provider login via access token

### DIFF
--- a/api/API/Controllers/ProveedorController.cs
+++ b/api/API/Controllers/ProveedorController.cs
@@ -100,6 +100,24 @@ namespace API.Controllers
 
             return Ok(new { ok = true, mensaje = "Proveedor válido." });
         }
+
+        [HttpPost("login")]
+        public async Task<IActionResult> Login([FromBody] ProveedorLoginRequest request)
+        {
+            if (request == null || string.IsNullOrWhiteSpace(request.Token))
+                return BadRequest(new { ok = false, mensaje = "Token inválido." });
+
+            var proveedor = await _proveedorFlujo.ObtenerPorToken(request.Token);
+
+            if (proveedor == null || proveedor.ProveedorId == Guid.Empty)
+                return Unauthorized(new { ok = false, mensaje = "QR inválido o expirado." });
+
+            return Ok(new
+            {
+                ok = true,
+                proveedor
+            });
+        }
         #endregion
 
         #region Helpers

--- a/api/Abstracciones/Interfaces/API/IProveedorController.cs
+++ b/api/Abstracciones/Interfaces/API/IProveedorController.cs
@@ -12,5 +12,6 @@ namespace Abstracciones.Interfaces.API
         Task<IActionResult> Eliminar(Guid Id);
         Task<IActionResult> Obtener();
         Task<IActionResult> Obtener(Guid Id);
+        Task<IActionResult> Login(ProveedorLoginRequest request);
     }
 }

--- a/api/Abstracciones/Interfaces/DA/IProveedorDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IProveedorDA.cs
@@ -15,5 +15,6 @@ namespace Abstracciones.Interfaces.DA
         Task<Guid> Editar(Guid Id, ProveedorRequest proveedor);
         Task<Guid> Eliminar(Guid Id);
         Task<bool> ExisteProveedor(Guid id);
+        Task<ProveedorDetalle?> ObtenerPorToken(string token);
     }
 }

--- a/api/Abstracciones/Interfaces/Flujo/IProveedorFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IProveedorFlujo.cs
@@ -15,5 +15,6 @@ namespace Abstracciones.Interfaces.Flujo
         Task<Guid> Editar(Guid Id, ProveedorRequest proveedor);
         Task<Guid> Eliminar(Guid Id);
         Task<bool> ExisteProveedor(Guid id);
+        Task<ProveedorDetalle?> ObtenerPorToken(string token);
     }
 }

--- a/api/Abstracciones/Modelos/Proveedor.cs
+++ b/api/Abstracciones/Modelos/Proveedor.cs
@@ -18,11 +18,13 @@ namespace Abstracciones.Modelos
     public class ProveedorRequest : ProveedorBase
     {
         // Para creación/edición
+        public string? AccessToken { get; set; }
     }
 
     public class ProveedorResponse : ProveedorBase
     {
         public Guid ProveedorId { get; set; }
+        public string? AccessToken { get; set; }
     }
 
     public class ProveedorDetalle : ProveedorResponse
@@ -30,5 +32,10 @@ namespace Abstracciones.Modelos
         // Información extendida para cuando se consulta el proveedor
         public string? Direccion { get; set; }
         public int? CantidadBeneficios { get; set; }
+    }
+
+    public class ProveedorLoginRequest
+    {
+        public string Token { get; set; } = string.Empty;
     }
 }

--- a/api/BD/BD.sqlproj
+++ b/api/BD/BD.sqlproj
@@ -78,6 +78,7 @@
     <Build Include="Security\core.sql" />
     <Build Include="core\Stored Procedures\ObtenerProveedores.sql" />
     <Build Include="core\Stored Procedures\ObtenerProveedor.sql" />
+    <Build Include="core\Stored Procedures\ObtenerProveedorPorToken.sql" />
     <Build Include="core\Stored Procedures\EliminarProveedor.sql" />
     <Build Include="core\Stored Procedures\EditarProveedor.sql" />
     <Build Include="core\Stored Procedures\AgregarProveedor.sql" />

--- a/api/BD/core/Stored Procedures/AgregarProveedor.sql
+++ b/api/BD/core/Stored Procedures/AgregarProveedor.sql
@@ -1,9 +1,10 @@
-﻿CREATE PROCEDURE [core].[AgregarProveedor]
-  @Nombre   NVARCHAR(120),
-  @Correo   NVARCHAR(120) = NULL,
-  @Telefono NVARCHAR(50)  = NULL,
-  @Direccion NVARCHAR(250)= NULL,
-  @Imagen   VARBINARY(MAX)= NULL
+CREATE PROCEDURE [core].[AgregarProveedor]
+  @Nombre     NVARCHAR(120),
+  @Correo     NVARCHAR(120) = NULL,
+  @Telefono   NVARCHAR(50)  = NULL,
+  @Direccion  NVARCHAR(250)= NULL,
+  @Imagen     VARBINARY(MAX)= NULL,
+  @AccessToken VARCHAR(128) = NULL
 AS
 BEGIN
   SET NOCOUNT ON;
@@ -14,8 +15,8 @@ BEGIN
   IF @Id IS NULL
   BEGIN
     SET @Id = NEWID();
-    INSERT core.Proveedor (ProveedorId, Nombre, Correo, Telefono, Direccion, Imagen)
-    VALUES (@Id, @Nombre, @Correo, @Telefono, @Direccion, @Imagen);
+    INSERT core.Proveedor (ProveedorId, Nombre, Correo, Telefono, Direccion, Imagen, AccessToken)
+    VALUES (@Id, @Nombre, @Correo, @Telefono, @Direccion, @Imagen, @AccessToken);
   END
 
   SELECT @Id AS ProveedorId;

--- a/api/BD/core/Stored Procedures/EditarProveedor.sql
+++ b/api/BD/core/Stored Procedures/EditarProveedor.sql
@@ -1,10 +1,11 @@
-﻿CREATE PROCEDURE [core].[EditarProveedor]
-  @Id        UNIQUEIDENTIFIER,
-  @Nombre    NVARCHAR(120),
-  @Correo    NVARCHAR(120) = NULL,
-  @Telefono  NVARCHAR(50)  = NULL,
-  @Direccion NVARCHAR(250) = NULL,
-  @Imagen    VARBINARY(MAX)= NULL
+CREATE PROCEDURE [core].[EditarProveedor]
+  @Id         UNIQUEIDENTIFIER,
+  @Nombre     NVARCHAR(120),
+  @Correo     NVARCHAR(120) = NULL,
+  @Telefono   NVARCHAR(50)  = NULL,
+  @Direccion  NVARCHAR(250) = NULL,
+  @Imagen     VARBINARY(MAX)= NULL,
+  @AccessToken VARCHAR(128) = NULL
 AS
 BEGIN
   SET NOCOUNT ON;
@@ -13,11 +14,12 @@ BEGIN
     THROW 50010, 'Nombre de proveedor ya existe.', 1;
 
   UPDATE p
-     SET p.Nombre    = @Nombre,
-         p.Correo    = @Correo,
-         p.Telefono  = @Telefono,
-         p.Direccion = @Direccion,
-         p.Imagen    = COALESCE(@Imagen, p.Imagen)
+     SET p.Nombre     = @Nombre,
+         p.Correo     = @Correo,
+         p.Telefono   = @Telefono,
+         p.Direccion  = @Direccion,
+         p.Imagen     = COALESCE(@Imagen, p.Imagen),
+         p.AccessToken = @AccessToken
   FROM core.Proveedor p
   WHERE p.ProveedorId = @Id;
 

--- a/api/BD/core/Stored Procedures/ObtenerProveedor.sql
+++ b/api/BD/core/Stored Procedures/ObtenerProveedor.sql
@@ -1,18 +1,19 @@
-﻿CREATE PROCEDURE [core].[ObtenerProveedor]
+CREATE PROCEDURE [core].[ObtenerProveedor]
   @Id UNIQUEIDENTIFIER
 AS
 BEGIN
   SET NOCOUNT ON;
 
-  SELECT 
+  SELECT
       p.ProveedorId,
       p.Nombre,
       p.Correo,
       p.Telefono,
       p.Direccion,
       p.Imagen,
-      (SELECT COUNT(*) 
-         FROM core.Beneficio b 
+      p.AccessToken,
+      (SELECT COUNT(*)
+         FROM core.Beneficio b
          WHERE b.ProveedorId = p.ProveedorId) AS CantidadBeneficios
   FROM core.Proveedor p
   WHERE p.ProveedorId = @Id;

--- a/api/BD/core/Stored Procedures/ObtenerProveedorPorToken.sql
+++ b/api/BD/core/Stored Procedures/ObtenerProveedorPorToken.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE core.ObtenerProveedorPorToken
+  @AccessToken VARCHAR(128)
+AS
+BEGIN
+  SET NOCOUNT ON;
+
+  SELECT TOP 1
+    ProveedorId,
+    Nombre,
+    Correo,
+    Telefono,
+    Direccion,
+    Imagen,
+    AccessToken
+  FROM core.Proveedor
+  WHERE AccessToken = @AccessToken;
+END;
+GO

--- a/api/BD/core/Stored Procedures/ObtenerProveedores.sql
+++ b/api/BD/core/Stored Procedures/ObtenerProveedores.sql
@@ -1,20 +1,21 @@
-﻿CREATE PROCEDURE [core].[ObtenerProveedores]
+CREATE PROCEDURE [core].[ObtenerProveedores]
 AS
 BEGIN
   SET NOCOUNT ON;
 
-  SELECT 
+  SELECT
       p.ProveedorId,
       p.Nombre,
       p.Correo,
       p.Telefono,
       p.Direccion,
       p.Imagen,
+      p.AccessToken,
       COUNT(b.BeneficioId) AS CantidadBeneficios
   FROM core.Proveedor p
   LEFT JOIN core.Beneficio b ON b.ProveedorId = p.ProveedorId
-  GROUP BY 
-      p.ProveedorId, p.Nombre, p.Correo, p.Telefono, p.Direccion, p.Imagen
-  ORDER BY 
+  GROUP BY
+      p.ProveedorId, p.Nombre, p.Correo, p.Telefono, p.Direccion, p.Imagen, p.AccessToken
+  ORDER BY
       p.Nombre;  -- (o p.ProveedorId si preferís)
 END

--- a/api/BD/core/Tables/Proveedor.sql
+++ b/api/BD/core/Tables/Proveedor.sql
@@ -1,10 +1,11 @@
-﻿CREATE TABLE [core].[Proveedor] (
+CREATE TABLE [core].[Proveedor] (
     [Nombre]      NVARCHAR (120)   NOT NULL,
     [Correo]      NVARCHAR (120)   NULL,
     [Telefono]    NVARCHAR (50)    NULL,
     [ProveedorId] UNIQUEIDENTIFIER DEFAULT (newid()) NOT NULL,
     [Direccion]   NVARCHAR (250)   NULL,
     [Imagen]      VARBINARY (MAX)  NULL,
+    [AccessToken] VARCHAR (128)    NULL,
     CONSTRAINT [PK_Proveedor] PRIMARY KEY CLUSTERED ([ProveedorId] ASC),
     CONSTRAINT [CK_Proveedor_Telefono_Length] CHECK ([Telefono] IS NULL OR len([Telefono])>=(7) AND len([Telefono])<=(50)),
     UNIQUE NONCLUSTERED ([Nombre] ASC)
@@ -17,3 +18,7 @@ GO
 CREATE UNIQUE NONCLUSTERED INDEX [UX_Proveedor_Nombre]
     ON [core].[Proveedor]([Nombre] ASC);
 
+GO
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Proveedor_AccessToken]
+    ON [core].[Proveedor]([AccessToken] ASC)
+    WHERE [AccessToken] IS NOT NULL;

--- a/api/DA/ProveedorDA.cs
+++ b/api/DA/ProveedorDA.cs
@@ -29,7 +29,8 @@ namespace DA
                     proveedor.Correo,
                     proveedor.Telefono,
                     proveedor.Imagen,
-                    proveedor.Direccion
+                    proveedor.Direccion,
+                    proveedor.AccessToken
                 },
                 null, null, CommandType.StoredProcedure
             );
@@ -48,7 +49,8 @@ namespace DA
                     proveedor.Correo,
                     proveedor.Telefono,
                     proveedor.Imagen,
-                    proveedor.Direccion
+                    proveedor.Direccion,
+                    proveedor.AccessToken
                 },
                 null, null, CommandType.StoredProcedure
             );
@@ -82,6 +84,21 @@ namespace DA
                 _dbConnection, sp, new { Id }, null, null, CommandType.StoredProcedure
             );
             return rows.FirstOrDefault() ?? new ProveedorDetalle();
+        }
+
+        public async Task<ProveedorDetalle?> ObtenerPorToken(string token)
+        {
+            const string sp = "core.ObtenerProveedorPorToken";
+            var rows = await _dapperWrapper.QueryAsync<ProveedorDetalle>(
+                _dbConnection,
+                sp,
+                new { AccessToken = token },
+                null,
+                null,
+                CommandType.StoredProcedure
+            );
+
+            return rows.FirstOrDefault();
         }
 
         public async Task<bool> ExisteProveedor(Guid id)

--- a/api/Flujo/ProveedorFlujo.cs
+++ b/api/Flujo/ProveedorFlujo.cs
@@ -47,5 +47,11 @@ namespace Flujo
             var existe = await _proveedorDA.ExisteProveedor(id);
             return existe;
         }
+
+        public async Task<ProveedorDetalle?> ObtenerPorToken(string token)
+        {
+            var proveedor = await _proveedorDA.ObtenerPorToken(token);
+            return proveedor;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add access-token support to the proveedor table with filtered unique index and updated CRUD stored procedures, plus a new login-by-token procedure
- expose provider access tokens through the models, data access, and flow layers and add a POST login endpoint that validates tokens
- include the new procedure in the database project for deployment

## Testing
- not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69405c2483b48322979435780b9f003a)