### PR TITLE
Add local admin seed script and bcrypt hash generator

### DIFF
--- a/BD/core/seed_admin_local.sql
+++ b/BD/core/seed_admin_local.sql
@@ -1,0 +1,127 @@
+/*
+    Seed local para bootstrap del usuario administrador.
+    - Crea schema y tabla core.tbAdminUsuario si no existen.
+    - Actualiza/crea los procedimientos necesarios para autenticación.
+    - Inserta el usuario admin inicial de forma idempotente usando un hash bcrypt provisto.
+*/
+
+-- Crear schema core si no existe
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'core')
+BEGIN
+    EXEC('CREATE SCHEMA core');
+END
+GO
+
+-- Crear tabla core.tbAdminUsuario si no existe
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = 'core' AND t.name = 'tbAdminUsuario'
+)
+BEGIN
+    CREATE TABLE [core].[tbAdminUsuario]
+    (
+        [AdminUsuarioId] UNIQUEIDENTIFIER NOT NULL DEFAULT (newsequentialid()),
+        [Usuario]        NVARCHAR(50)    NOT NULL,
+        [Nombre]         NVARCHAR(100)   NULL,
+        [Correo]         NVARCHAR(150)   NULL,
+        [PasswordHash]   NVARCHAR(200)   NOT NULL,
+        [Activo]         BIT             NOT NULL DEFAULT ((1)),
+        [FechaCreacion]  DATETIME2 (3)   NOT NULL DEFAULT (sysdatetime()),
+        [UltimoLogin]    DATETIME2 (3)   NULL,
+        CONSTRAINT [PK_tbAdminUsuario] PRIMARY KEY CLUSTERED ([AdminUsuarioId] ASC),
+        CONSTRAINT [UQ_tbAdminUsuario_Usuario] UNIQUE NONCLUSTERED ([Usuario] ASC)
+    );
+END
+GO
+
+/* =========================================================
+   core.AdminUsuario_Login
+   Busca un administrador por Usuario y devuelve su hash para
+   validar en la capa de aplicación.
+   ========================================================= */
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_Login]
+    @Usuario NVARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        AdminUsuarioId,
+        Usuario,
+        Nombre,
+        Correo,
+        PasswordHash,
+        Activo,
+        FechaCreacion,
+        UltimoLogin
+    FROM core.tbAdminUsuario
+    WHERE Usuario = @Usuario;
+END
+GO
+
+/* =========================================================
+   core.AdminUsuario_Crear
+   Crea un administrador usando el hash de password provisto.
+   ========================================================= */
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_Crear]
+    @Usuario      NVARCHAR(50),
+    @Nombre       NVARCHAR(100) = NULL,
+    @Correo       NVARCHAR(150) = NULL,
+    @PasswordHash NVARCHAR(200),
+    @Activo       BIT = 1
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @NuevoId UNIQUEIDENTIFIER = NEWID();
+
+    INSERT INTO core.tbAdminUsuario
+    (
+        AdminUsuarioId,
+        Usuario,
+        Nombre,
+        Correo,
+        PasswordHash,
+        Activo
+    )
+    VALUES
+    (
+        @NuevoId,
+        @Usuario,
+        @Nombre,
+        @Correo,
+        @PasswordHash,
+        @Activo
+    );
+
+    SELECT @NuevoId AS AdminUsuarioId;
+END
+GO
+
+/* =========================================================
+   core.AdminUsuario_ActualizarUltimoLogin
+   Actualiza la fecha de último login para el administrador.
+   ========================================================= */
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_ActualizarUltimoLogin]
+    @AdminUsuarioId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE core.tbAdminUsuario
+    SET UltimoLogin = sysdatetime()
+    WHERE AdminUsuarioId = @AdminUsuarioId;
+
+    SELECT @AdminUsuarioId AS AdminUsuarioId;
+END
+GO
+
+-- Insertar administrador inicial de forma idempotente
+IF NOT EXISTS (SELECT 1 FROM core.tbAdminUsuario WHERE Usuario = 'admin')
+BEGIN
+    INSERT INTO core.tbAdminUsuario (AdminUsuarioId, Usuario, Nombre, Correo, PasswordHash, Activo)
+    VALUES (NEWID(), 'admin', 'Administrador', 'admin@hrbeneficios.local', '__BCRYPT_HASH_AQUI__', 1);
+END
+GO

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # 📚 Modelo de Datos – Beneficios-PR
 
-Este proyecto contiene la base de datos y módulos para la gestión de beneficios.  
+Este proyecto contiene la base de datos y módulos para la gestión de beneficios.
 A continuación se muestra el diagrama entidad–relación (ERD) en **Mermaid**:
+
+## Admin local
+
+- El password real del usuario `admin` lo define cada desarrollador en su entorno local y se reemplaza en `BD/core/seed_admin_local.sql` con un hash bcrypt.
+- El hash bcrypt es unidireccional y no puede revertirse a texto plano; conservar el secreto del password original queda a cargo del desarrollador.
+- Para resetear el admin local se puede eliminar la fila con `Usuario='admin'` en `core.tbAdminUsuario` y volver a ejecutar el seed.
 
 ```mermaid
 erDiagram

--- a/api/BD/core/Stored Procedures/AdminUsuario_ActualizarUltimoLogin.sql
+++ b/api/BD/core/Stored Procedures/AdminUsuario_ActualizarUltimoLogin.sql
@@ -2,7 +2,7 @@
    core.AdminUsuario_ActualizarUltimoLogin
    Actualiza la fecha de último login para el administrador.
    ========================================================= */
-CREATE PROCEDURE [core].[AdminUsuario_ActualizarUltimoLogin]
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_ActualizarUltimoLogin]
     @AdminUsuarioId UNIQUEIDENTIFIER
 AS
 BEGIN

--- a/api/BD/core/Stored Procedures/AdminUsuario_Crear.sql
+++ b/api/BD/core/Stored Procedures/AdminUsuario_Crear.sql
@@ -2,7 +2,7 @@
    core.AdminUsuario_Crear
    Crea un administrador usando el hash de password provisto.
    ========================================================= */
-CREATE PROCEDURE [core].[AdminUsuario_Crear]
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_Crear]
     @Usuario      NVARCHAR(50),
     @Nombre       NVARCHAR(100) = NULL,
     @Correo       NVARCHAR(150) = NULL,
@@ -12,7 +12,7 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    DECLARE @NuevoId UNIQUEIDENTIFIER = NEWSEQUENTIALID();
+    DECLARE @NuevoId UNIQUEIDENTIFIER = NEWID();
 
     INSERT INTO core.tbAdminUsuario
     (

--- a/api/BD/core/Stored Procedures/AdminUsuario_Login.sql
+++ b/api/BD/core/Stored Procedures/AdminUsuario_Login.sql
@@ -3,9 +3,8 @@
    Busca un administrador por Usuario y devuelve su hash para
    validar en la capa de aplicación.
    ========================================================= */
-CREATE PROCEDURE [core].[AdminUsuario_Login]
-    @Usuario  NVARCHAR(50),
-    @Password NVARCHAR(200)
+CREATE OR ALTER PROCEDURE [core].[AdminUsuario_Login]
+    @Usuario NVARCHAR(50)
 AS
 BEGIN
     SET NOCOUNT ON;

--- a/api/DA/AdminAuthDA.cs
+++ b/api/DA/AdminAuthDA.cs
@@ -23,7 +23,7 @@ namespace DA
             var admin = await _dapperWrapper.QueryFirstOrDefaultAsync<AdminUsuario>(
                 _dbConnection,
                 sp,
-                new { Usuario = usuario, Password = string.Empty },
+                new { Usuario = usuario },
                 commandType: CommandType.StoredProcedure
             );
             return admin;

--- a/tools/HashGenerator/HashGenerator.csproj
+++ b/tools/HashGenerator/HashGenerator.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+  </ItemGroup>
+</Project>

--- a/tools/HashGenerator/Program.cs
+++ b/tools/HashGenerator/Program.cs
@@ -1,0 +1,25 @@
+using System;
+using BCrypt.Net;
+
+namespace HashGenerator;
+
+internal class Program
+{
+    private static void Main()
+    {
+        Console.WriteLine("Generador de hash bcrypt para admin local\n");
+        Console.Write("Ingrese el password a hashear: ");
+        var password = Console.ReadLine();
+
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            Console.WriteLine("\nNo se ingresó un password válido.");
+            return;
+        }
+
+        var hash = BCrypt.Net.BCrypt.HashPassword(password);
+
+        Console.WriteLine("\nHash generado (copiar y pegar en seed_admin_local.sql):");
+        Console.WriteLine(hash);
+    }
+}

--- a/tools/HashGenerator/README.md
+++ b/tools/HashGenerator/README.md
@@ -1,0 +1,15 @@
+# HashGenerator
+
+Utilitario de consola para generar el hash bcrypt del password inicial del usuario admin.
+
+## Pasos
+
+1. Instalar la dependencia de bcrypt:
+   ```bash
+   dotnet add package BCrypt.Net-Next
+   ```
+2. Ejecutar el generador y escribir el password deseado:
+   ```bash
+   dotnet run
+   ```
+3. Copiar el hash generado y pegarlo en `BD/core/seed_admin_local.sql`, reemplazando `__BCRYPT_HASH_AQUI__`.


### PR DESCRIPTION
## Summary
- add an idempotent SQL seed to create the admin schema/table, procedures, and placeholder credentials for local environments
- align admin stored procedures and data access to use database-backed bcrypt hashes and NEWID() identifiers
- add a bcrypt hash console utility and README notes on managing the local admin user

## Testing
- not run (dotnet CLI not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940c1b8251c832290981b150a7fdc02)