### PR TITLE
Add portal proveedor token middleware

### DIFF
--- a/api/API/Controllers/ProveedorController.cs
+++ b/api/API/Controllers/ProveedorController.cs
@@ -4,10 +4,10 @@ using Abstracciones.Modelos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
+using System.Security.Claims;
 
 namespace API.Controllers
 {
-    [Authorize(Roles = "Admin")]
     [Route("api/[controller]")]
     [ApiController]
     public class ProveedorController : ControllerBase, IProveedorController
@@ -23,6 +23,7 @@ namespace API.Controllers
 
         #region Operaciones
         [HttpPost]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Agregar([FromBody] ProveedorRequest proveedor)
         {
             if (string.IsNullOrWhiteSpace(proveedor?.Nombre))
@@ -35,6 +36,7 @@ namespace API.Controllers
         }
 
         [HttpPut("{Id:guid}")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Editar([FromRoute] Guid Id, [FromBody] ProveedorRequest proveedor)
         {
             // Validación de entrada
@@ -59,6 +61,7 @@ namespace API.Controllers
         }
 
         [HttpDelete("{Id:guid}")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Eliminar([FromRoute] Guid Id)
         {
             var actual = await _proveedorFlujo.Obtener(Id);
@@ -76,6 +79,7 @@ namespace API.Controllers
         }
 
         [HttpGet]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Obtener()
         {
             var resultado = await _proveedorFlujo.Obtener();
@@ -86,6 +90,7 @@ namespace API.Controllers
         }
 
         [HttpGet("{Id:guid}")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Obtener([FromRoute] Guid Id)
         {
             var resultado = await _proveedorFlujo.Obtener(Id);
@@ -93,6 +98,7 @@ namespace API.Controllers
         }
 
         [HttpGet("validar-login/{Id:guid}")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> ValidarLogin([FromRoute] Guid Id)
         {
             var existe = await _proveedorFlujo.ExisteProveedor(Id);
@@ -104,6 +110,7 @@ namespace API.Controllers
         }
 
         [HttpPost("login")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> Login([FromBody] ProveedorLoginRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.Token))
@@ -113,6 +120,27 @@ namespace API.Controllers
 
             if (proveedor == null || proveedor.ProveedorId == Guid.Empty)
                 return Unauthorized(new { ok = false, mensaje = "QR inválido o expirado." });
+
+            return Ok(new
+            {
+                ok = true,
+                proveedor
+            });
+        }
+
+        [HttpGet("portal/perfil")]
+        [Authorize(Roles = "Proveedor")]
+        public async Task<IActionResult> ObtenerPerfil()
+        {
+            var proveedorIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (!Guid.TryParse(proveedorIdClaim, out var proveedorId))
+                return Unauthorized(new { ok = false, mensaje = "Proveedor no autenticado." });
+
+            var proveedor = await _proveedorFlujo.Obtener(proveedorId);
+
+            if (proveedor is null)
+                return NotFound(new { ok = false, mensaje = "Proveedor no encontrado." });
 
             return Ok(new
             {

--- a/api/API/Middleware/PortalProveedorMiddleware.cs
+++ b/api/API/Middleware/PortalProveedorMiddleware.cs
@@ -1,0 +1,59 @@
+﻿using Abstracciones.Interfaces.Flujo;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace API.Middleware
+{
+    public class PortalProveedorMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public PortalProveedorMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context, IProveedorFlujo proveedorFlujo)
+        {
+            if (context.User?.Identity?.IsAuthenticated == true)
+            {
+                await _next(context);
+                return;
+            }
+
+            if (!context.Request.Headers.TryGetValue("X-Token", out var tokenValues))
+            {
+                await _next(context);
+                return;
+            }
+
+            var token = tokenValues.FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                await _next(context);
+                return;
+            }
+
+            var proveedor = await proveedorFlujo.ObtenerPorToken(token);
+
+            if (proveedor is null)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsJsonAsync(new { ok = false, mensaje = "Token inválido o expirado." });
+                return;
+            }
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, proveedor.ProveedorId.ToString()),
+                new Claim(ClaimTypes.Name, proveedor.Nombre),
+                new Claim(ClaimTypes.Role, "Proveedor")
+            };
+
+            context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "PortalProveedor"));
+
+            await _next(context);
+        }
+    }
+}

--- a/api/API/Program.cs
+++ b/api/API/Program.cs
@@ -4,6 +4,7 @@ using Abstracciones.Interfaces.Flujo;
 using Abstracciones.Interfaces.Reglas;
 using Abstracciones.Interfaces.Servicios;
 using Abstracciones.Modelos.Servicios;
+using API.Middleware;
 using DA;
 using Flujo;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -222,6 +223,7 @@ app.UseHttpsRedirection();
 app.UseRouting();
 app.UseCors(WebCors);
 app.UseAuthentication();
+app.UseMiddleware<PortalProveedorMiddleware>();
 app.UseAuthorization();
 
 // Swagger también en PROD: útil para probar rápidamente

--- a/api/Abstracciones/Interfaces/API/IProveedorController.cs
+++ b/api/Abstracciones/Interfaces/API/IProveedorController.cs
@@ -12,6 +12,8 @@ namespace Abstracciones.Interfaces.API
         Task<IActionResult> Eliminar(Guid Id);
         Task<IActionResult> Obtener();
         Task<IActionResult> Obtener(Guid Id);
+        Task<IActionResult> ValidarLogin(Guid Id);
         Task<IActionResult> Login(ProveedorLoginRequest request);
+        Task<IActionResult> ObtenerPerfil();
     }
 }


### PR DESCRIPTION
## Summary
- add a middleware to authenticate portal proveedor requests via X-Token using IProveedorFlujo and inject proveedor claims
- register the portal middleware in the pipeline before authorization without altering existing JWT flow
- add a proveedor-only profile endpoint using role-based authorization as an example usage

## Testing
- not run (dotnet CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944e04fa3108322a76a216e8a44165f)