### PR TITLE
Handle category deletion conflicts with reassignment modal

### DIFF
--- a/api/Abstracciones/Interfaces/API/IBeneficioController.cs
+++ b/api/Abstracciones/Interfaces/API/IBeneficioController.cs
@@ -13,5 +13,7 @@ namespace Abstracciones.Interfaces.API
         Task<IActionResult> ObtenerPendientes();
         Task<IActionResult> Aprobar(Guid Id);
         Task<IActionResult> Rechazar(Guid Id);
+        Task<IActionResult> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search);
+        Task<IActionResult> ReasignarCategoria(ReasignarCategoriaRequest request);
     }
 }

--- a/api/Abstracciones/Interfaces/DA/IBeneficioDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IBeneficioDA.cs
@@ -19,5 +19,8 @@ namespace Abstracciones.Interfaces.DA
         Task<Guid> Eliminar(Guid Id);
         Task<Guid> Aprobar(Guid Id, Guid? usuarioId);
         Task<Guid> Rechazar(Guid Id, Guid? usuarioId);
+        Task<PagedResult<BeneficioResponse>> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search);
+        Task<int> ReasignarCategoria(Guid fromCategoriaId, Guid toCategoriaId, IEnumerable<Guid>? beneficioIds);
+        Task<int> ContarPorCategoria(Guid categoriaId);
     }
 }

--- a/api/Abstracciones/Interfaces/Flujo/IBeneficioFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IBeneficioFlujo.cs
@@ -20,5 +20,8 @@ namespace Abstracciones.Interfaces.Flujo
         Task<Guid> Eliminar(Guid Id);
         Task<Guid> Aprobar(Guid Id, Guid? usuarioId);
         Task<Guid> Rechazar(Guid Id, Guid? usuarioId);
+        Task<PagedResult<BeneficioResponse>> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search);
+        Task<int> ReasignarCategoria(Guid fromCategoriaId, Guid toCategoriaId, IEnumerable<Guid>? beneficioIds);
+        Task<int> ContarPorCategoria(Guid categoriaId);
     }
 }

--- a/api/Abstracciones/Modelos/CategoriaEnUso.cs
+++ b/api/Abstracciones/Modelos/CategoriaEnUso.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Abstracciones.Modelos
+{
+    public class CategoriaEnUsoResponse
+    {
+        public string Code { get; set; } = "CategoriaEnUso";
+        public string Message { get; set; } = "La categoría tiene beneficios asociados.";
+        public Guid CategoriaId { get; set; }
+        
+        public int Count { get; set; }
+    }
+
+    public class CategoriaEnUsoException : Exception
+    {
+        public Guid CategoriaId { get; }
+        public int BeneficiosCount { get; }
+
+        public CategoriaEnUsoException(Guid categoriaId, int beneficiosCount, string? message = null, Exception? innerException = null)
+            : base(message ?? "La categoría tiene beneficios asociados.", innerException)
+        {
+            CategoriaId = categoriaId;
+            BeneficiosCount = beneficiosCount;
+        }
+    }
+}

--- a/api/Abstracciones/Modelos/ReasignarCategoriaRequest.cs
+++ b/api/Abstracciones/Modelos/ReasignarCategoriaRequest.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Abstracciones.Modelos
+{
+    public class ReasignarCategoriaRequest
+    {
+        [Required]
+        public Guid FromCategoriaId { get; set; }
+
+        [Required]
+        public Guid ToCategoriaId { get; set; }
+
+        public IEnumerable<Guid>? BeneficioIds { get; set; }
+    }
+}

--- a/api/BD/core/Stored Procedures/ObtenerBeneficiosPorCategoria.sql
+++ b/api/BD/core/Stored Procedures/ObtenerBeneficiosPorCategoria.sql
@@ -1,0 +1,56 @@
+﻿CREATE PROCEDURE core.ObtenerBeneficiosPorCategoria
+    @CategoriaId UNIQUEIDENTIFIER,
+    @Page INT = 1,
+    @PageSize INT = 50,
+    @Search NVARCHAR(200) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SET @Page = CASE WHEN @Page < 1 THEN 1 ELSE @Page END;
+    SET @PageSize = CASE WHEN @PageSize < 1 THEN 50 ELSE @PageSize END;
+
+    DECLARE @Offset INT = (@Page - 1) * @PageSize;
+    DECLARE @Pattern NVARCHAR(202) = NULL;
+
+    IF (@Search IS NOT NULL AND LTRIM(RTRIM(@Search)) <> '')
+        SET @Pattern = '%' + LTRIM(RTRIM(@Search)) + '%';
+
+    ;WITH base AS (
+        SELECT
+            b.BeneficioId,
+            b.Titulo,
+            b.Descripcion,
+            b.PrecioCRC,
+            b.Condiciones,
+            b.VigenciaInicio,
+            b.VigenciaFin,
+            b.Disponible,
+            b.Origen,
+            b.CreadoEn,
+            b.ModificadoEn,
+            b.Imagen,
+            b.CategoriaId,
+            b.ProveedorId,
+            b.Estado,
+            b.FechaCreacion,
+            b.FechaAprobacion,
+            b.AprobadoPorUsuarioId,
+            p.Nombre AS ProveedorNombre,
+            c.Nombre AS CategoriaNombre
+        FROM core.Beneficio b
+        INNER JOIN core.Proveedor p ON p.ProveedorId = b.ProveedorId
+        INNER JOIN core.Categoria c ON c.CategoriaId = b.CategoriaId
+        WHERE b.CategoriaId = @CategoriaId
+          AND (
+            @Pattern IS NULL OR
+            b.Titulo LIKE @Pattern OR
+            p.Nombre LIKE @Pattern
+          )
+    )
+    SELECT *,
+           Total = COUNT(*) OVER()
+    FROM base
+    ORDER BY FechaCreacion DESC
+    OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY;
+END

--- a/api/BD/core/Stored Procedures/ReasignarBeneficiosCategoria.sql
+++ b/api/BD/core/Stored Procedures/ReasignarBeneficiosCategoria.sql
@@ -1,0 +1,40 @@
+﻿CREATE PROCEDURE core.ReasignarBeneficiosCategoria
+    @FromCategoriaId UNIQUEIDENTIFIER,
+    @ToCategoriaId UNIQUEIDENTIFIER,
+    @BeneficioIds NVARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @FromCategoriaId = @ToCategoriaId
+        THROW 50021, 'La categoría destino debe ser diferente.', 1;
+
+    DECLARE @Actualizados INT = 0;
+
+    IF (@BeneficioIds IS NOT NULL AND LTRIM(RTRIM(@BeneficioIds)) <> '')
+    BEGIN
+        DECLARE @Ids TABLE (Id UNIQUEIDENTIFIER PRIMARY KEY);
+        INSERT INTO @Ids (Id)
+        SELECT TRY_CAST(value AS UNIQUEIDENTIFIER)
+        FROM STRING_SPLIT(@BeneficioIds, ',')
+        WHERE TRY_CAST(value AS UNIQUEIDENTIFIER) IS NOT NULL;
+
+        UPDATE b
+            SET b.CategoriaId = @ToCategoriaId
+        FROM core.Beneficio b
+        INNER JOIN @Ids ids ON ids.Id = b.BeneficioId
+        WHERE b.CategoriaId = @FromCategoriaId;
+
+        SET @Actualizados = @@ROWCOUNT;
+    END
+    ELSE
+    BEGIN
+        UPDATE core.Beneficio
+        SET CategoriaId = @ToCategoriaId
+        WHERE CategoriaId = @FromCategoriaId;
+
+        SET @Actualizados = @@ROWCOUNT;
+    END
+
+    SELECT @Actualizados AS Actualizados;
+END

--- a/api/DA/CategoriaDA.cs
+++ b/api/DA/CategoriaDA.cs
@@ -50,6 +50,10 @@ namespace DA
         public async Task<Guid> Eliminar(Guid Id)
         {
             await verficarCategoriaExiste(Id);
+            var asociados = await ContarBeneficiosAsociados(Id);
+            if (asociados > 0)
+                throw new CategoriaEnUsoException(Id, asociados);
+
             const string sp = "core.EliminarCategoria";
             var id = await _dapperWrapper.ExecuteScalarAsync<Guid>(
                 _dbConnection, sp, new { Id },
@@ -83,6 +87,13 @@ namespace DA
             var dto = await Obtener(Id);
             if (dto == null || dto.CategoriaId == Guid.Empty)
                 throw new Exception("No se encontro la categoria");
+        }
+
+        private async Task<int> ContarBeneficiosAsociados(Guid categoriaId)
+        {
+            const string sql = "SELECT COUNT(1) FROM core.Beneficio WHERE CategoriaId = @categoriaId";
+            var total = await _dapperWrapper.ExecuteScalarAsync<int>(_dbConnection, sql, new { categoriaId });
+            return total;
         }
         #endregion
     }

--- a/api/Flujo/BeneficiosFlujo.cs
+++ b/api/Flujo/BeneficiosFlujo.cs
@@ -62,5 +62,20 @@ namespace Flujo
         {
             return await _beneficioDA.Rechazar(id, usuarioId);
         }
+
+        public async Task<PagedResult<BeneficioResponse>> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search)
+        {
+            return await _beneficioDA.ObtenerPorCategoria(categoriaId, page, pageSize, search);
+        }
+
+        public async Task<int> ReasignarCategoria(Guid fromCategoriaId, Guid toCategoriaId, IEnumerable<Guid>? beneficioIds)
+        {
+            return await _beneficioDA.ReasignarCategoria(fromCategoriaId, toCategoriaId, beneficioIds);
+        }
+
+        public async Task<int> ContarPorCategoria(Guid categoriaId)
+        {
+            return await _beneficioDA.ContarPorCategoria(categoriaId);
+        }
     }
 }

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminShell.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/AdminShell.jsx
@@ -27,6 +27,10 @@ export default function AdminShell() {
     addCategoria,
     addProveedor,
     upsertProveedorLocal,
+    categoriaEnUso,
+    showCategoriaEnUso,
+    setCategoriaEnUso,
+    setShowCategoriaEnUso,
     showForm,
     setShowForm,
     editing,
@@ -96,6 +100,7 @@ export default function AdminShell() {
         {/* Contenido principal */}
         <AdminMain
           nav={nav}
+          setNav={setNav}
           // beneficios
           state={beneficiosState}
           beneficios={beneficios}
@@ -108,6 +113,10 @@ export default function AdminShell() {
   deleteCategoria={deleteCategoria}
           addProveedor={addProveedor}
           upsertProveedorLocal={upsertProveedorLocal}
+          categoriaEnUso={categoriaEnUso}
+          showCategoriaEnUso={showCategoriaEnUso}
+          setCategoriaEnUso={setCategoriaEnUso}
+          setShowCategoriaEnUso={setShowCategoriaEnUso}
           // formulario
           showForm={showForm}
           setShowForm={setShowForm}

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/modals/CategoriaEnUsoModal.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/modals/CategoriaEnUsoModal.jsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from "react";
+import { BeneficioApi } from "../../../services/adminApi";
+
+const PAGE_SIZE = 50;
+
+const normId = (v) => (v == null ? "" : String(v).trim());
+const getCatId = (r) =>
+  normId(
+    r?.id ??
+      r?.Id ??
+      r?.categoriaId ??
+      r?.CategoriaId ??
+      r?.categoriaID ??
+      r?.CategoriaID ??
+      r?.idCategoria ??
+      r?.IdCategoria ??
+      r?.categoria?.id ??
+      r?.categoria?.Id
+  );
+
+export default function CategoriaEnUsoModal({
+  open,
+  onClose,
+  categoria,
+  cats = [],
+  onReasignar,
+  onEditBenefit,
+}) {
+  const [items, setItems] = useState([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState(new Set());
+  const [destCatId, setDestCatId] = useState("");
+  const categoriaId = useMemo(() => getCatId(categoria), [categoria]);
+
+  const selectableCats = useMemo(
+    () => cats.filter((c) => getCatId(c) && getCatId(c) !== categoriaId),
+    [cats, categoriaId]
+  );
+
+  useEffect(() => {
+    if (!open || !categoriaId) return;
+    setItems([]);
+    setPage(1);
+    setTotal(0);
+    setSelected(new Set());
+    setDestCatId("");
+    setSearch("");
+    cargar(1, false, "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, categoriaId]);
+
+  const cargar = async (nextPage = 1, append = false, currentSearch = search) => {
+    if (!categoriaId) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await BeneficioApi.listByCategoria(categoriaId, nextPage, PAGE_SIZE, currentSearch);
+      const nuevos = Array.isArray(res?.items) ? res.items : [];
+      setTotal(res?.total ?? 0);
+      setPage(nextPage);
+      setItems((prev) => (append ? [...prev, ...nuevos] : nuevos));
+    } catch (err) {
+      console.error("No se pudo cargar la lista de beneficios", err);
+      setError("No se pudo cargar la lista de beneficios.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleSelect = (id) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const moveSelected = async () => {
+    if (!destCatId) {
+      setError("Selecciona la categoría destino.");
+      return;
+    }
+    const ids = Array.from(selected);
+    await onReasignar?.({
+      fromCategoriaId: categoriaId,
+      toCategoriaId: destCatId,
+      beneficioIds: ids.length > 0 ? ids : null,
+      beneficios: items.filter((b) => ids.length === 0 || ids.includes(b.beneficioId || b.id)),
+    });
+    setSelected(new Set());
+    setDestCatId("");
+  };
+
+  const canLoadMore = items.length < total;
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm px-4 py-8 overflow-y-auto">
+      <div className="max-w-5xl mx-auto bg-neutral-950 border border-white/10 rounded-2xl p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/50">Categoría en uso</p>
+            <h2 className="text-xl font-semibold">
+              {categoria?.nombre ?? categoria?.titulo ?? "Categoría"}
+            </h2>
+            {categoria?.detalle?.count != null && (
+              <p className="text-sm text-white/60">
+                Beneficios asociados: {categoria.detalle.count}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-full text-sm bg-white/5 hover:bg-white/10"
+          >
+            Cerrar
+          </button>
+        </div>
+
+        <div className="grid md:grid-cols-[2fr_1fr] gap-4">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <input
+                placeholder="Buscar beneficio"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="flex-1 rounded-xl bg-neutral-900 border border-white/10 px-3 py-2 text-sm"
+              />
+              <button
+                onClick={() => cargar(1, false, search)}
+                className="px-3 py-2 rounded-xl bg-white/10 hover:bg-white/20 text-sm"
+              >
+                Buscar
+              </button>
+              <button
+                onClick={() => {
+                  setSearch("");
+                  cargar(1, false, "");
+                }}
+                className="px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 text-sm"
+              >
+                Limpiar
+              </button>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 divide-y divide-white/5 bg-black/40">
+              {items.map((b) => {
+                const id = normId(b?.beneficioId ?? b?.id);
+                const checked = selected.has(id);
+                return (
+                  <div key={id || b.titulo} className="px-4 py-3 flex items-start gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleSelect(id)}
+                      className="mt-1"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold leading-tight">{b.titulo || "(Sin título)"}</p>
+                      <p className="text-xs text-white/60">
+                        {b.proveedorNombre || "Proveedor"} · {b.categoriaNombre || "Categoría"}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => onEditBenefit?.(b)}
+                      className="px-3 py-1 rounded-full text-xs bg-white/5 hover:bg-white/10"
+                    >
+                      Editar
+                    </button>
+                  </div>
+                );
+              })}
+
+              {!loading && items.length === 0 && (
+                <p className="px-4 py-6 text-sm text-white/50">No hay beneficios para esta categoría.</p>
+              )}
+
+              {loading && (
+                <p className="px-4 py-3 text-sm text-white/60">Cargando beneficios…</p>
+              )}
+            </div>
+
+            {canLoadMore && (
+              <button
+                onClick={() => cargar(page + 1, true, search)}
+                className="px-3 py-2 rounded-full text-sm bg-white/10 hover:bg-white/20"
+                disabled={loading}
+              >
+                Cargar más
+              </button>
+            )}
+          </div>
+
+          <div className="space-y-3 rounded-2xl border border-white/10 p-4 bg-black/40">
+            <h3 className="font-semibold">Reasignar beneficios</h3>
+            <p className="text-xs text-white/60">
+              Selecciona uno o más beneficios, o deja la selección vacía para mover todos.
+            </p>
+            <div className="space-y-2">
+              <label className="text-sm text-white/70 block">Categoría destino</label>
+              <select
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                value={destCatId}
+                onChange={(e) => setDestCatId(e.target.value)}
+              >
+                <option value="">Seleccione</option>
+                {selectableCats.map((c) => (
+                  <option key={getCatId(c)} value={getCatId(c)}>
+                    {c.nombre ?? c.titulo}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {error && <p className="text-sm text-red-300">{error}</p>}
+
+            <button
+              onClick={moveSelected}
+              disabled={loading}
+              className="w-full px-4 py-2 rounded-full bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-60"
+            >
+              Mover {selected.size > 0 ? `${selected.size} seleccionado(s)` : "todos"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/CategoriasPage.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/CategoriasPage.jsx
@@ -39,11 +39,14 @@ export default function CategoriasPage({
   Renombrar
 </button>
 
-<button
-  onClick={() => {
-    console.log("deleteCategoria is", deleteCategoria);
-    console.log("row c", c);
-    return deleteCategoria?.(c);
+            <button
+  onClick={async () => {
+    try {
+      await deleteCategoria?.(c);
+    } catch (err) {
+      console.error("No se pudo eliminar la categoría", err);
+      return err;
+    }
   }}
   className="ml-2 px-2 py-1 rounded-full text-xs bg-white/5 hover:bg-red-500/20 text-red-300/90"
 >

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/useAdminShell.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/useAdminShell.js
@@ -21,6 +21,10 @@ export default function useAdminShell() {
 const {
   cats,
   provs,
+  categoriaEnUso,
+  showCategoriaEnUso,
+  setCategoriaEnUso,
+  setShowCategoriaEnUso,
 
   addCategoria,
   renameCategoria,
@@ -54,6 +58,10 @@ const {
     addCategoria,
     addProveedor,
     upsertProveedorLocal,
+    categoriaEnUso,
+    showCategoriaEnUso,
+    setCategoriaEnUso,
+    setShowCategoriaEnUso,
 
     // formulario crear / editar
     showForm,

--- a/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
@@ -2,6 +2,15 @@
 import { clearAuth, getAuth } from "../utils/adminAuth";
 import { API_BASE } from "./apiBase";
 
+export class ApiError extends Error {
+  constructor(message, status, data) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
 export function authHeader() {
   const auth = getAuth();
   if (!auth?.access_token) return {};
@@ -42,10 +51,18 @@ async function req(path, { method = "GET", json, headers, signal } = {}) {
     throw new Error("unauthorized");
   }
 
-  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}`);
+  const contentType = res.headers.get("content-type") || "";
+  const isJson = contentType.includes("application/json");
+  const payload = isJson ? await res.json().catch(() => null) : await res.text().catch(() => null);
+
+  if (!res.ok) {
+    const message = payload?.message || `${method} ${path} → ${res.status}`;
+    throw new ApiError(message, res.status, payload);
+  }
+
   if (res.status === 204) return null;
   const ct = res.headers.get("content-type") || "";
-  return ct.includes("application/json") ? res.json() : res.text();
+  return ct.includes("application/json") ? payload : payload;
 }
 
 export const BeneficioApi = {
@@ -54,6 +71,16 @@ export const BeneficioApi = {
   create:(dto,o={}) => req("/api/Beneficio", { method:"POST", json:dto, ...o }),
   update:(id,dto,o={}) => req(`/api/Beneficio/${id}`, { method:"PUT", json:dto, ...o }),
   remove:(id,o={}) => req(`/api/Beneficio/${id}`, { method:"DELETE", ...o }),
+  listByCategoria: (categoriaId, page = 1, pageSize = 50, search = "", o = {}) => {
+    const params = new URLSearchParams({
+      page: String(page),
+      pageSize: String(pageSize),
+    });
+    if (search) params.set("search", search);
+    return req(`/api/Beneficio/por-categoria/${categoriaId}?${params.toString()}`, o);
+  },
+  reassignCategoria: (body, o = {}) =>
+    req(`/api/Beneficio/reasignar-categoria`, { method: "PUT", json: body, ...o }),
   pending: (o={}) => req("/api/Beneficio/pendientes", o),
   approve: (id,o={}) => req(`/api/Beneficio/${id}/aprobar`, { method:"PUT", json:{}, ...o }),
   reject:  (id,body={},o={}) => req(`/api/Beneficio/${id}/rechazar`, { method:"PUT", json:body, ...o }),


### PR DESCRIPTION
## Summary
- Return 409 with structured payload when deleting categories that still have benefits and add counting/exception handling
- Add admin API endpoints to list benefits by category and reassign them between categories
- Update admin UI to catch 409 deletes, show a paginated reassignment modal, and call new APIs to move or edit blocking benefits

## Testing
- ⚠️ `dotnet test` *(not run: dotnet CLI not available in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a341dd288322bd22f2c81879baf8)