### PR TITLE
Fix paginated benefits by category

### DIFF
--- a/api/Abstracciones/Modelos/BeneficioPorCategoriaRow.cs
+++ b/api/Abstracciones/Modelos/BeneficioPorCategoriaRow.cs
@@ -1,0 +1,10 @@
+﻿namespace Abstracciones.Modelos
+{
+    /// <summary>
+    /// Representa un registro devuelto por core.ObtenerBeneficiosPorCategoria que incluye el total paginado.
+    /// </summary>
+    public class BeneficioPorCategoriaRow : BeneficioResponse
+    {
+        public int Total { get; set; }
+    }
+}

--- a/api/DA/BeneficioDA.cs
+++ b/api/DA/BeneficioDA.cs
@@ -132,7 +132,7 @@ namespace DA
         {
             const string sp = "core.ObtenerBeneficiosPorCategoria";
 
-            var rows = await _dapperWrapper.QueryAsync<BeneficioConTotal>(
+            var rows = await _dapperWrapper.QueryAsync<BeneficioPorCategoriaRow>(
                 _dbConnection,
                 sp,
                 new
@@ -145,12 +145,12 @@ namespace DA
                 commandType: CommandType.StoredProcedure
             );
 
-            var lista = rows?.ToList() ?? new List<BeneficioConTotal>();
+            var lista = rows?.ToList() ?? new List<BeneficioPorCategoriaRow>();
             var total = lista.FirstOrDefault()?.Total ?? 0;
 
             return new PagedResult<BeneficioResponse>
             {
-                Items = lista,
+                Items = lista.Cast<BeneficioResponse>().ToList(),
                 Page = page,
                 PageSize = pageSize,
                 Total = total
@@ -194,9 +194,5 @@ namespace DA
         }
         #endregion
 
-        private class BeneficioConTotal : BeneficioResponse
-        {
-            public int Total { get; set; }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- add a DTO for beneficio results that captures the Total column from core.ObtenerBeneficiosPorCategoria
- update BeneficioDA to map stored procedure results into the paged response and keep pagination metadata intact

## Testing
- dotnet build HR-Beneficios-API.sln *(fails: dotnet CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b01370648322bbee493013c74509)