### PR TITLE
Ensure InfoBoard admin requests use authenticated wrapper

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/services/adminApi.js
@@ -129,3 +129,22 @@ export const ToqueBeneficioApi = {
       ...o,
     }),
 };
+
+export const InfoBoardApi = {
+  list: ({ activo, search, q } = {}, o = {}) => {
+    const params = new URLSearchParams();
+    const hasActivo = activo !== undefined && activo !== null && activo !== "";
+    if (hasActivo) params.set("activo", String(activo));
+    const searchTerm = (search ?? q)?.toString().trim();
+    if (searchTerm) {
+      params.set("search", searchTerm);
+      params.set("q", searchTerm);
+    }
+    const qs = params.toString();
+    return req(`/api/InfoBoard${qs ? `?${qs}` : ""}`, o);
+  },
+  get: (id, o = {}) => req(`/api/InfoBoard/${id}`, o),
+  create: (dto, o = {}) => req(`/api/InfoBoard`, { method: "POST", json: dto, ...o }),
+  update: (id, dto, o = {}) => req(`/api/InfoBoard/${id}`, { method: "PUT", json: dto, ...o }),
+  remove: (id, o = {}) => req(`/api/InfoBoard/${id}`, { method: "DELETE", ...o }),
+};

--- a/clon/AdminBeneficiosFinalPublicado/src/services/infoBoardService.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/services/infoBoardService.js
@@ -1,22 +1,4 @@
-const API_BASE = (import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
-
-async function request(path, { method = "GET", json, expectList = false } = {}) {
-  const res = await fetch(`${API_BASE}${path}`, {
-    method,
-    headers: {
-      Accept: "application/json",
-      ...(json ? { "Content-Type": "application/json" } : {}),
-    },
-    body: json ? JSON.stringify(json) : undefined,
-    mode: "cors",
-  });
-
-  if (res.status === 204) return expectList ? [] : null;
-  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}`);
-
-  const ct = res.headers.get("content-type") || "";
-  return ct.includes("application/json") ? res.json() : res.text();
-}
+import { InfoBoardApi } from "./adminApi";
 
 const normalize = (v) => (typeof v === "string" ? v.trim() : v ?? "");
 const toBool = (v) => Boolean(v === true || v === "true" || v === 1 || v === "1");
@@ -36,14 +18,11 @@ export function mapInfoBoard(raw) {
 }
 
 export async function list({ activo, q } = {}) {
-  const params = new URLSearchParams();
-  if (activo !== undefined && activo !== null) params.set("activo", String(activo));
-  if (q) params.set("q", q.trim());
-  const qs = params.toString();
-  return request(`/api/InfoBoard${qs ? `?${qs}` : ""}`, { expectList: true });
+  const search = q?.trim() || undefined;
+  return InfoBoardApi.list({ activo, search });
 }
 
-export const getById = (id) => request(`/api/InfoBoard/${id}`);
-export const create = (payload) => request(`/api/InfoBoard`, { method: "POST", json: payload });
-export const update = (id, payload) => request(`/api/InfoBoard/${id}`, { method: "PUT", json: payload });
-export const remove = (id) => request(`/api/InfoBoard/${id}`, { method: "DELETE" });
+export const getById = (id) => InfoBoardApi.get(id);
+export const create = (payload) => InfoBoardApi.create(payload);
+export const update = (id, payload) => InfoBoardApi.update(id, payload);
+export const remove = (id) => InfoBoardApi.remove(id);


### PR DESCRIPTION
## Summary
- add InfoBoardApi to the shared admin client using the authenticated request helper
- route InfoBoard service calls through the new API while keeping existing mapping helpers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694759d9444483228dd126cc218ba361)