### PR TITLE
Validate badge token on beneficio creation

### DIFF
--- a/api/Abstracciones/Interfaces/API/IBeneficioController.cs
+++ b/api/Abstracciones/Interfaces/API/IBeneficioController.cs
@@ -7,7 +7,7 @@ namespace Abstracciones.Interfaces.API
     {
         Task<IActionResult> Obtener();
         Task<IActionResult> Obtener(Guid Id);
-        Task<IActionResult> Agregar(BeneficioRequest beneficio);
+        Task<IActionResult> Agregar(BeneficioRequest beneficio, Guid proveedorId, string token);
         Task<IActionResult> Editar(Guid Id, BeneficioRequest beneficio);
         Task<IActionResult> Eliminar(Guid Id);
         Task<IActionResult> ObtenerPendientes();

--- a/api/Abstracciones/Interfaces/DA/IBeneficioDA.cs
+++ b/api/Abstracciones/Interfaces/DA/IBeneficioDA.cs
@@ -22,5 +22,6 @@ namespace Abstracciones.Interfaces.DA
         Task<PagedResult<BeneficioResponse>> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search);
         Task<int> ReasignarCategoria(Guid fromCategoriaId, Guid toCategoriaId, IEnumerable<Guid>? beneficioIds);
         Task<int> ContarPorCategoria(Guid categoriaId);
+        Task<bool> ValidarTokenBadge(Guid proveedorId, string token);
     }
 }

--- a/api/Abstracciones/Interfaces/Flujo/IBeneficioFlujo.cs
+++ b/api/Abstracciones/Interfaces/Flujo/IBeneficioFlujo.cs
@@ -23,5 +23,6 @@ namespace Abstracciones.Interfaces.Flujo
         Task<PagedResult<BeneficioResponse>> ObtenerPorCategoria(Guid categoriaId, int page, int pageSize, string? search);
         Task<int> ReasignarCategoria(Guid fromCategoriaId, Guid toCategoriaId, IEnumerable<Guid>? beneficioIds);
         Task<int> ContarPorCategoria(Guid categoriaId);
+        Task<bool> ValidarTokenBadge(Guid proveedorId, string token);
     }
 }

--- a/api/DA/BeneficioDA.cs
+++ b/api/DA/BeneficioDA.cs
@@ -183,6 +183,26 @@ namespace DA
             const string sql = "SELECT COUNT(1) FROM core.Beneficio WHERE CategoriaId = @categoriaId";
             return await _dapperWrapper.ExecuteScalarAsync<int>(_dbConnection, sql, new { categoriaId });
         }
+
+        public async Task<bool> ValidarTokenBadge(Guid proveedorId, string token)
+        {
+            const string sql = @"SELECT 1
+FROM core.Proveedor
+WHERE ProveedorId = @ProveedorId
+  AND AccessToken = @Token;";
+
+            var result = await _dapperWrapper.QueryFirstOrDefaultAsync<int>(
+                _dbConnection,
+                sql,
+                new
+                {
+                    ProveedorId = proveedorId,
+                    Token = token
+                }
+            );
+
+            return result == 1;
+        }
         #endregion
 
         #region Helpers

--- a/api/Flujo/BeneficiosFlujo.cs
+++ b/api/Flujo/BeneficiosFlujo.cs
@@ -77,5 +77,10 @@ namespace Flujo
         {
             return await _beneficioDA.ContarPorCategoria(categoriaId);
         }
+
+        public async Task<bool> ValidarTokenBadge(Guid proveedorId, string token)
+        {
+            return await _beneficioDA.ValidarTokenBadge(proveedorId, token);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate provider badge tokens for anonymous beneficio creation via query parameters
- add badge token validation method through flujo and Dapper data access layers
- ensure requests use the queried provider ID before creating benefits

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a6361c4c83229122f8f5ac3098f1)