### PR TITLE
Refactor Admin benefits slice to Clean Architecture (use-cases, gateways, ui hooks)

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/BenefitsList.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/BenefitsList.jsx
@@ -90,7 +90,7 @@ export default function BenefitsList({
                 className={`flex items-center px-4 py-3 gap-3 cursor-pointer ${
                   isActive ? "bg-white/5" : "hover:bg-white/5/60"
                 }`}
-                onClick={() => onSelect?.({ ...b, id: itemId, beneficioId: itemId })}
+                onClick={() => onSelect?.(b)}
               >
                 {/* mini imagen */}
                 <div className="w-10 h-10 rounded-md bg-white/10 overflow-hidden flex-shrink-0" />
@@ -119,7 +119,7 @@ export default function BenefitsList({
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    onEdit?.({ ...b, id: itemId, beneficioId: itemId });
+                    onEdit?.(b);
                   }}
                   className="ml-2 px-3 py-1.5 rounded-full text-[11px] border border-white/15 hover:bg-white/10"
                 >

--- a/clon/AdminBeneficiosFinalPublicado/src/components/beneficio/CardBeneficio.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/beneficio/CardBeneficio.jsx
@@ -1,62 +1,9 @@
 // src/components/beneficio/CardBeneficio.jsx
-import React, { useEffect, useState } from "react";
-import { BeneficioApi } from "../../services/adminApi"; // ⟵ desde /components/beneficio a /components/services
-
-// Normaliza cualquier forma de imagen hacia algo válido para <img src="...">
-function toDisplaySrc(raw) {
-  const s = String(raw ?? "").trim();
-  if (!s) return "";
-  // ya es URL absoluta, data URL o blob
-  if (/^(data:|https?:|blob:)/i.test(s)) return s;
-  // ¿parece base64 crudo?
-  const looksB64 = /^[A-Za-z0-9+/=\s]+$/.test(s) && s.replace(/\s/g, "").length > 50;
-  if (looksB64) return `data:image/jpeg;base64,${s.replace(/\s/g, "")}`;
-  // algún path relativo u otro esquema
-  return s;
-}
+import React from "react";
+import { useBenefitCardImage } from "../../ui/hooks/useBenefitCardImage";
 
 export default function CardBeneficio({ item, onEdit, onDelete }) {
-  // intenta con lo que venga en la card (url, base64, etc.)
-  const [src, setSrc] = useState(() =>
-    toDisplaySrc(
-      item?.imagenUrl ?? item?.ImagenUrl ??
-      item?.imagenBase64 ?? item?.ImagenBase64 ??
-      item?.imagen ?? item?.Imagen ?? ""
-    )
-  );
-
-  // Si no hay imagen en la card, hidrata desde el detalle del beneficio
-  useEffect(() => {
-    let cancel = false;
-
-    // si el item se actualiza y ahora trae algo inline, úsalo
-    const inlineRaw =
-      item?.imagenUrl ?? item?.ImagenUrl ??
-      item?.imagenBase64 ?? item?.ImagenBase64 ??
-      item?.imagen ?? item?.Imagen ?? "";
-    if (!src && inlineRaw) {
-      setSrc(toDisplaySrc(inlineRaw));
-      return;
-    }
-
-    // si seguimos sin src y hay id, pide el detalle para intentar obtener imagen
-    (async () => {
-      if (src || !item?.id) return;
-      try {
-        const full = await BeneficioApi.get(item.id);
-        if (cancel) return;
-        const raw =
-          full?.imagenUrl ?? full?.ImagenUrl ??
-          full?.imagenBase64 ?? full?.ImagenBase64 ??
-          full?.imagen ?? full?.Imagen ?? "";
-        if (raw) setSrc(toDisplaySrc(raw));
-      } catch {
-        // silencioso: si falla, dejamos "Sin imagen"
-      }
-    })();
-
-    return () => { cancel = true; };
-  }, [item?.id, item?.imagen, item?.imagenUrl, src]);
+  const { containerRef, src } = useBenefitCardImage(item);
 
   const precio = item?.precioCRC ?? item?.precio ?? null;
 
@@ -68,7 +15,10 @@ export default function CardBeneficio({ item, onEdit, onDelete }) {
     {item?.categoriaNombre || "—"}
   </span>
 </div>
-        <div className="aspect-video bg-neutral-800 grid place-items-center text-white/50">
+        <div
+          ref={containerRef}
+          className="aspect-video bg-neutral-800 grid place-items-center text-white/50"
+        >
           {src ? (
             <img className="w-full h-full object-cover" src={src} alt={item?.titulo || ""} />
           ) : (

--- a/clon/AdminBeneficiosFinalPublicado/src/core-config/gateways.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core-config/gateways.js
@@ -1,0 +1,22 @@
+import { API_BASE } from "../services/apiBase";
+import { adminSessionStore } from "./sessionStores";
+import { createFetchClient } from "../core/infrastructure/http/createFetchClient";
+import { BeneficioGatewayFetch } from "../core/infrastructure/http/BeneficioGatewayFetch";
+import { CategoriaGatewayFetch } from "../core/infrastructure/http/CategoriaGatewayFetch";
+import { ProveedorGatewayFetch } from "../core/infrastructure/http/ProveedorGatewayFetch";
+import { ToqueBeneficioGatewayFetch } from "../core/infrastructure/http/ToqueBeneficioGatewayFetch";
+
+const fetchClient = createFetchClient({
+  baseUrl: API_BASE,
+  sessionStore: adminSessionStore,
+  onUnauthorized: () => {
+    if (typeof window !== "undefined") {
+      window.location.replace("/login");
+    }
+  },
+});
+
+export const beneficioGateway = new BeneficioGatewayFetch(fetchClient);
+export const categoriaGateway = new CategoriaGatewayFetch(fetchClient);
+export const proveedorGateway = new ProveedorGatewayFetch(fetchClient);
+export const toqueBeneficioGateway = new ToqueBeneficioGatewayFetch(fetchClient);

--- a/clon/AdminBeneficiosFinalPublicado/src/core-config/useCases.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core-config/useCases.js
@@ -1,0 +1,50 @@
+import {
+  beneficioGateway,
+  categoriaGateway,
+  proveedorGateway,
+  toqueBeneficioGateway,
+} from "./gateways";
+import { loadBeneficiosList as loadBeneficiosListUseCase } from "../core/flujo/use-cases/LoadBeneficiosList";
+import { loadCategoriasList as loadCategoriasListUseCase } from "../core/flujo/use-cases/LoadCategoriasList";
+import { loadProveedoresList as loadProveedoresListUseCase } from "../core/flujo/use-cases/LoadProveedoresList";
+import { getBeneficioDetail as getBeneficioDetailUseCase } from "../core/flujo/use-cases/GetBeneficioDetail";
+import { getBenefitCardImage as getBenefitCardImageUseCase } from "../core/flujo/use-cases/GetBenefitCardImage";
+import { loadToqueAnalytics as loadToqueAnalyticsUseCase } from "../core/flujo/use-cases/LoadToqueAnalytics";
+import { loadToqueSummary as loadToqueSummaryUseCase } from "../core/flujo/use-cases/LoadToqueSummary";
+import { saveBeneficio as saveBeneficioUseCase } from "../core/flujo/use-cases/SaveBeneficio";
+import { deleteBeneficio as deleteBeneficioUseCase } from "../core/flujo/use-cases/DeleteBeneficio";
+
+export const loadBeneficiosList = () =>
+  loadBeneficiosListUseCase({ beneficioGateway });
+
+export const loadCategoriasList = () =>
+  loadCategoriasListUseCase({ categoriaGateway });
+
+export const loadProveedoresList = () =>
+  loadProveedoresListUseCase({ proveedorGateway });
+
+export const getBeneficioDetail = (beneficioId) =>
+  getBeneficioDetailUseCase({ beneficioGateway, beneficioId });
+
+export const getBenefitCardImage = (beneficio) =>
+  getBenefitCardImageUseCase({ beneficioGateway, beneficio });
+
+export const loadToqueAnalytics = ({ beneficioId, range }) =>
+  loadToqueAnalyticsUseCase({
+    toqueBeneficioGateway,
+    beneficioId,
+    range,
+  });
+
+export const loadToqueSummary = ({ range, beneficios }) =>
+  loadToqueSummaryUseCase({
+    toqueBeneficioGateway,
+    range,
+    beneficios,
+  });
+
+export const saveBeneficio = ({ dto, editing }) =>
+  saveBeneficioUseCase({ beneficioGateway, dto, editing });
+
+export const deleteBeneficio = ({ beneficioId }) =>
+  deleteBeneficioUseCase({ beneficioGateway, beneficioId });

--- a/clon/AdminBeneficiosFinalPublicado/src/core/README.md
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/README.md
@@ -15,6 +15,11 @@ Apps must remain independent. The core must not import React or router libraries
 
 ## Usage
 
+- UI can only call Flow (Flujo) use-cases.
+- Flow depends only on Abstracciones + Reglas.
+- Infrastructure implements Abstracciones and is injected into Flow.
+- UI cannot access HTTP or storage directly.
+
 - Instantiate a `LocalSessionStore` with an app-specific key.
 - Use `validateSessionAndAuthorize` to decide what to render:
   - `OK`

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/BeneficioGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/BeneficioGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} BeneficioGateway
+ * @property {(options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/BeneficioImagenGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/BeneficioImagenGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} BeneficioImagenGateway
+ * @property {(beneficioId: string, options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/CategoriaGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/CategoriaGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} CategoriaGateway
+ * @property {(options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/InfoBoardGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/InfoBoardGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} InfoBoardGateway
+ * @property {(filters?: object, options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/ProveedorGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/ProveedorGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} ProveedorGateway
+ * @property {(options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/RifaParticipacionGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/RifaParticipacionGateway.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {Object} RifaParticipacionGateway
+ * @property {(filters?: object, options?: object) => Promise<any>} list
+ * @property {(id: string, options?: object) => Promise<any>} get
+ * @property {(dto: object, options?: object) => Promise<any>} create
+ * @property {(id: string, dto: object, options?: object) => Promise<any>} update
+ * @property {(id: string, options?: object) => Promise<any>} remove
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/ToqueBeneficioGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/ToqueBeneficioGateway.js
@@ -1,0 +1,7 @@
+/**
+ * @typedef {Object} ToqueBeneficioGateway
+ * @property {(beneficioId: string, range?: string, options?: object, granularity?: string) => Promise<any>} analytics
+ * @property {(range?: string, options?: object) => Promise<any>} resumen
+ * @property {(beneficioId: string, origen: string, options?: object) => Promise<any>} registrar
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Beneficio.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Beneficio.js
@@ -1,0 +1,18 @@
+/**
+ * @typedef {Object} Beneficio
+ * @property {string} [id]
+ * @property {string} [beneficioId]
+ * @property {string} [titulo]
+ * @property {string} [nombre]
+ * @property {string} [categoriaId]
+ * @property {string} [categoriaNombre]
+ * @property {string} [proveedorId]
+ * @property {string} [proveedorNombre]
+ * @property {string} [imagenUrl]
+ * @property {string} [imagenBase64]
+ * @property {string} [imagen]
+ * @property {number} [precioCRC]
+ * @property {number} [precio]
+ * @property {number} [totalToques]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/BeneficioImagen.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/BeneficioImagen.js
@@ -1,0 +1,10 @@
+/**
+ * @typedef {Object} BeneficioImagen
+ * @property {string} [id]
+ * @property {string} [beneficioId]
+ * @property {string} [imagen]
+ * @property {string} [imagenBase64]
+ * @property {string} [imagenUrl]
+ * @property {string} [url]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Categoria.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Categoria.js
@@ -1,0 +1,8 @@
+/**
+ * @typedef {Object} Categoria
+ * @property {string} [id]
+ * @property {string} [categoriaId]
+ * @property {string} [nombre]
+ * @property {string} [titulo]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/InfoBoard.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/InfoBoard.js
@@ -1,0 +1,11 @@
+/**
+ * @typedef {Object} InfoBoard
+ * @property {string} [id]
+ * @property {string} [titulo]
+ * @property {string} [descripcion]
+ * @property {string} [url]
+ * @property {string} [tipo]
+ * @property {string} [fechaInicio]
+ * @property {string} [fechaFin]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Proveedor.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/Proveedor.js
@@ -1,0 +1,8 @@
+/**
+ * @typedef {Object} Proveedor
+ * @property {string} [id]
+ * @property {string} [proveedorId]
+ * @property {string} [nombre]
+ * @property {string} [accessToken]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/RifaParticipacion.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/models/RifaParticipacion.js
@@ -1,0 +1,8 @@
+/**
+ * @typedef {Object} RifaParticipacion
+ * @property {string} [id]
+ * @property {string} [rifaId]
+ * @property {string} [beneficioId]
+ * @property {string} [usuarioId]
+ */
+export {};

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/DeleteBeneficio.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/DeleteBeneficio.js
@@ -1,0 +1,4 @@
+export async function deleteBeneficio({ beneficioGateway, beneficioId }) {
+  if (!beneficioId) return;
+  await beneficioGateway.remove(beneficioId);
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/GetBeneficioDetail.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/GetBeneficioDetail.js
@@ -1,0 +1,7 @@
+import { normalizeBeneficio } from "../../reglas/mapping/beneficio";
+
+export async function getBeneficioDetail({ beneficioGateway, beneficioId }) {
+  if (!beneficioId) return null;
+  const data = await beneficioGateway.get(beneficioId);
+  return normalizeBeneficio(data);
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/GetBenefitCardImage.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/GetBenefitCardImage.js
@@ -1,0 +1,18 @@
+import {
+  normalizeBeneficioId,
+  normalizeImageSource,
+  pickBeneficioImage,
+} from "../../reglas/mapping/beneficio";
+
+export async function getBenefitCardImage({ beneficioGateway, beneficio }) {
+  if (!beneficio) return "";
+
+  const inline = normalizeImageSource(pickBeneficioImage(beneficio));
+  if (inline) return inline;
+
+  const id = normalizeBeneficioId(beneficio);
+  if (!id) return "";
+
+  const detail = await beneficioGateway.get(id);
+  return normalizeImageSource(pickBeneficioImage(detail));
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadBeneficiosList.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadBeneficiosList.js
@@ -1,0 +1,6 @@
+import { normalizeBeneficiosList } from "../../reglas/mapping/beneficio";
+
+export async function loadBeneficiosList({ beneficioGateway }) {
+  const data = await beneficioGateway.list();
+  return normalizeBeneficiosList(data);
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadCategoriasList.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadCategoriasList.js
@@ -1,0 +1,4 @@
+export async function loadCategoriasList({ categoriaGateway }) {
+  const data = await categoriaGateway.list();
+  return Array.isArray(data) ? data : [];
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadProveedoresList.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadProveedoresList.js
@@ -1,0 +1,4 @@
+export async function loadProveedoresList({ proveedorGateway }) {
+  const data = await proveedorGateway.list();
+  return Array.isArray(data) ? data : [];
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadToqueAnalytics.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadToqueAnalytics.js
@@ -1,0 +1,7 @@
+import { normalizeToqueAnalytics } from "../../reglas/mapping/beneficio";
+
+export async function loadToqueAnalytics({ toqueBeneficioGateway, beneficioId, range }) {
+  if (!beneficioId) return null;
+  const data = await toqueBeneficioGateway.analytics(beneficioId, range);
+  return normalizeToqueAnalytics(data);
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadToqueSummary.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoadToqueSummary.js
@@ -1,0 +1,13 @@
+import {
+  mergeBeneficiosWithSummary,
+  normalizeToqueSummary,
+} from "../../reglas/mapping/beneficio";
+
+export async function loadToqueSummary({ toqueBeneficioGateway, range, beneficios }) {
+  const data = await toqueBeneficioGateway.resumen(range);
+  const summary = normalizeToqueSummary(data);
+  return {
+    summary,
+    beneficios: mergeBeneficiosWithSummary(beneficios, summary),
+  };
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/SaveBeneficio.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/SaveBeneficio.js
@@ -1,0 +1,25 @@
+import { normalizeBeneficio, normalizeBeneficiosList, normalizeBeneficioId } from "../../reglas/mapping/beneficio";
+
+export async function saveBeneficio({ beneficioGateway, dto, editing }) {
+  const id = normalizeBeneficioId(editing);
+
+  if (id) {
+    await beneficioGateway.update(id, dto);
+    const fresh = await beneficioGateway.get(id);
+    return { beneficio: normalizeBeneficio(fresh) };
+  }
+
+  const created = await beneficioGateway.create(dto);
+  let raw = created;
+
+  if (raw == null) {
+    const list = await beneficioGateway.list();
+    return { beneficios: normalizeBeneficiosList(list) };
+  }
+
+  if (typeof raw === "string") {
+    raw = await beneficioGateway.get(raw);
+  }
+
+  return { beneficio: normalizeBeneficio(raw) };
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/BeneficioGatewayFetch.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/BeneficioGatewayFetch.js
@@ -1,0 +1,25 @@
+export class BeneficioGatewayFetch {
+  constructor(client) {
+    this.client = client;
+  }
+
+  list(options = {}) {
+    return this.client.request("/api/Beneficio", options);
+  }
+
+  get(id, options = {}) {
+    return this.client.request(`/api/Beneficio/${id}`, options);
+  }
+
+  create(dto, options = {}) {
+    return this.client.request("/api/Beneficio", { method: "POST", json: dto, ...options });
+  }
+
+  update(id, dto, options = {}) {
+    return this.client.request(`/api/Beneficio/${id}`, { method: "PUT", json: dto, ...options });
+  }
+
+  remove(id, options = {}) {
+    return this.client.request(`/api/Beneficio/${id}`, { method: "DELETE", ...options });
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/CategoriaGatewayFetch.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/CategoriaGatewayFetch.js
@@ -1,0 +1,25 @@
+export class CategoriaGatewayFetch {
+  constructor(client) {
+    this.client = client;
+  }
+
+  list(options = {}) {
+    return this.client.request("/api/Categoria", options);
+  }
+
+  get(id, options = {}) {
+    return this.client.request(`/api/Categoria/${id}`, options);
+  }
+
+  create(dto, options = {}) {
+    return this.client.request("/api/Categoria", { method: "POST", json: dto, ...options });
+  }
+
+  update(id, dto, options = {}) {
+    return this.client.request(`/api/Categoria/${id}`, { method: "PUT", json: dto, ...options });
+  }
+
+  remove(id, options = {}) {
+    return this.client.request(`/api/Categoria/${id}`, { method: "DELETE", ...options });
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/ProveedorGatewayFetch.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/ProveedorGatewayFetch.js
@@ -1,0 +1,25 @@
+export class ProveedorGatewayFetch {
+  constructor(client) {
+    this.client = client;
+  }
+
+  list(options = {}) {
+    return this.client.request("/api/Proveedor", options);
+  }
+
+  get(id, options = {}) {
+    return this.client.request(`/api/Proveedor/${id}`, options);
+  }
+
+  create(dto, options = {}) {
+    return this.client.request("/api/Proveedor", { method: "POST", json: dto, ...options });
+  }
+
+  update(id, dto, options = {}) {
+    return this.client.request(`/api/Proveedor/${id}`, { method: "PUT", json: dto, ...options });
+  }
+
+  remove(id, options = {}) {
+    return this.client.request(`/api/Proveedor/${id}`, { method: "DELETE", ...options });
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/ToqueBeneficioGatewayFetch.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/ToqueBeneficioGatewayFetch.js
@@ -1,0 +1,26 @@
+export class ToqueBeneficioGatewayFetch {
+  constructor(client) {
+    this.client = client;
+  }
+
+  analytics(beneficioId, range = "1W", options = {}, granularity) {
+    const params = new URLSearchParams({ range });
+    if (granularity) params.set("granularity", granularity);
+    return this.client.request(
+      `/api/ToqueBeneficio/analytics/${beneficioId}?${params.toString()}`,
+      options
+    );
+  }
+
+  resumen(range = "1W", options = {}) {
+    return this.client.request(`/api/ToqueBeneficio/resumen?range=${range}`, options);
+  }
+
+  registrar(beneficioId, origen, options = {}) {
+    return this.client.request("/api/ToqueBeneficio", {
+      method: "POST",
+      json: { beneficioId, origen },
+      ...options,
+    });
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/createFetchClient.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/http/createFetchClient.js
@@ -1,0 +1,64 @@
+import { isSessionExpired } from "../../reglas/session/isSessionExpired";
+
+export class ApiError extends Error {
+  constructor(message, status, data) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+export function createFetchClient({ baseUrl, sessionStore, onUnauthorized } = {}) {
+  const normalizedBase = String(baseUrl ?? "").replace(/\/+$/, "");
+
+  const buildAuthHeader = () => {
+    const session = sessionStore?.getSession?.();
+    if (!session?.access_token) return {};
+
+    if (isSessionExpired(session)) {
+      sessionStore?.clearSession?.();
+      return {};
+    }
+
+    const type = session.token_type || "Bearer";
+    return { Authorization: `${type} ${session.access_token}`.trim() };
+  };
+
+  const request = async (path, { method = "GET", json, headers, signal, mode } = {}) => {
+    const res = await fetch(`${normalizedBase}${path}`, {
+      method,
+      headers: {
+        Accept: "application/json",
+        ...(json ? { "Content-Type": "application/json" } : {}),
+        ...buildAuthHeader(),
+        ...headers,
+      },
+      body: json ? JSON.stringify(json) : undefined,
+      signal,
+      mode: mode ?? "cors",
+    });
+
+    if (res.status === 401) {
+      sessionStore?.clearSession?.();
+      onUnauthorized?.();
+      throw new Error("unauthorized");
+    }
+
+    const contentType = res.headers.get("content-type") || "";
+    const isJson = contentType.includes("application/json");
+    const payload = isJson
+      ? await res.json().catch(() => null)
+      : await res.text().catch(() => null);
+
+    if (!res.ok) {
+      const message = payload?.message || `${method} ${path} → ${res.status}`;
+      throw new ApiError(message, res.status, payload);
+    }
+
+    if (res.status === 204) return null;
+    return payload;
+  };
+
+  return { request };
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/reglas/mapping/beneficio.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/reglas/mapping/beneficio.js
@@ -1,0 +1,86 @@
+export function normalizeBeneficioId(raw) {
+  const id =
+    raw?.id ??
+    raw?.Id ??
+    raw?.beneficioId ??
+    raw?.BeneficioId ??
+    raw?.beneficio?.id ??
+    raw?.beneficio?.Id;
+
+  const fixed = String(id ?? "").trim();
+  return fixed || "";
+}
+
+export function normalizeBeneficio(raw) {
+  if (!raw || typeof raw !== "object") return raw;
+  const id = normalizeBeneficioId(raw);
+  return {
+    ...raw,
+    id: id || undefined,
+    beneficioId: id || undefined,
+  };
+}
+
+export function normalizeBeneficiosList(rawList) {
+  return Array.isArray(rawList) ? rawList.map(normalizeBeneficio) : [];
+}
+
+export function pickBeneficioImage(raw) {
+  if (!raw || typeof raw !== "object") return "";
+  return (
+    raw?.imagenUrl ??
+    raw?.ImagenUrl ??
+    raw?.imagenBase64 ??
+    raw?.ImagenBase64 ??
+    raw?.imagen ??
+    raw?.Imagen ??
+    ""
+  );
+}
+
+export function normalizeImageSource(raw) {
+  const s = String(raw ?? "").trim();
+  if (!s) return "";
+  if (/^(data:|https?:|blob:)/i.test(s)) return s;
+  const looksB64 = /^[A-Za-z0-9+/=\s]+$/.test(s) && s.replace(/\s/g, "").length > 50;
+  if (looksB64) return `data:image/jpeg;base64,${s.replace(/\s/g, "")}`;
+  return s;
+}
+
+export function normalizeToqueSummary(raw) {
+  const arr = Array.isArray(raw)
+    ? raw
+    : Object.entries(raw || {}).map(([beneficioId, count]) => ({
+        beneficioId,
+        count,
+      }));
+
+  return arr.reduce((acc, curr) => {
+    const id = normalizeBeneficioId(curr);
+    if (!id) return acc;
+    acc[id] = curr?.count ?? curr?.Count ?? 0;
+    return acc;
+  }, {});
+}
+
+export function mergeBeneficiosWithSummary(beneficios, summary) {
+  const base = Array.isArray(beneficios) ? beneficios : [];
+  return base.map((beneficio) => {
+    const normalized = normalizeBeneficio(beneficio);
+    const total = summary?.[normalized?.beneficioId] ?? 0;
+    return { ...beneficio, totalToques: total };
+  });
+}
+
+export function normalizeToqueAnalytics(raw) {
+  if (!raw || typeof raw !== "object") return raw;
+  const series = Array.isArray(raw.series)
+    ? raw.series
+    : Array.isArray(raw.Series)
+      ? raw.Series
+      : [];
+  return {
+    ...raw,
+    series,
+  };
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/ui/hooks/useBenefitCardImage.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/ui/hooks/useBenefitCardImage.js
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { getBenefitCardImage } from "../../core-config/useCases";
+
+export function useBenefitCardImage(beneficio) {
+  const containerRef = useRef(null);
+  const hasRequestedRef = useRef(false);
+  const [src, setSrc] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setSrc("");
+    setLoading(false);
+    hasRequestedRef.current = false;
+  }, [beneficio]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let observer;
+
+    const loadImage = async () => {
+      if (hasRequestedRef.current) return;
+      hasRequestedRef.current = true;
+      setLoading(true);
+      try {
+        const resolved = await getBenefitCardImage(beneficio);
+        if (!cancelled) setSrc(resolved || "");
+      } catch {
+        if (!cancelled) setSrc("");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    const node = containerRef.current;
+    if (!node) {
+      loadImage();
+      return () => {};
+    }
+
+    if (typeof window !== "undefined" && "IntersectionObserver" in window) {
+      observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            observer.disconnect();
+            loadImage();
+          }
+        },
+        { rootMargin: "200px" }
+      );
+      observer.observe(node);
+    } else {
+      loadImage();
+    }
+
+    return () => {
+      cancelled = true;
+      if (observer) observer.disconnect();
+    };
+  }, [beneficio]);
+
+  return { containerRef, src, loading };
+}


### PR DESCRIPTION
### Motivation
- Apply Clean Architecture to the Admin app's first vertical slice so UI becomes thin and all feature logic flows through core layers.
- Reduce component size ("Short Components") by moving API, mapping and lazy-load logic out of `CardBeneficio` and dashboard components.
- Keep existing visuals, routes and independent app build behavior (`npm install && npm run build`).
- Enable an incremental pattern to migrate the rest of the app and the other three apps using the same contracts and adapters.

### Description
- Added Clean Architecture surface under `src/core`: `abstracciones` (models + gateway contracts), `reglas/mapping` (normalizers and mappers), `flujo/use-cases` (business orchestrators) and `infrastructure/http` (fetch-based gateway implementations).
- Introduced `src/core-config/gateways.js` and `src/core-config/useCases.js` as simple factories that wire infrastructure adapters to use-cases and expose UI-friendly functions like `loadBeneficiosList`, `getBenefitCardImage`, `loadToqueSummary`, `saveBeneficio`, and `deleteBeneficio`.
- Moved image normalization + detail-fetch logic into `src/core/reglas/mapping/beneficio.js` and `src/core/flujo/use-cases/GetBenefitCardImage.js`, and added `src/ui/hooks/useBenefitCardImage.js` to handle view concerns (IntersectionObserver + calling the use-case).
- Refactored UI to call use-cases/hooks only: updated `src/components/beneficio/CardBeneficio.jsx`, `src/components/AdminShell/pages/BenefitsList.jsx`, `src/components/AdminShell/pages/DashboardBeneficios.jsx` and `src/hooks/useBeneficios.js` to consume the new core use-cases; left `src/services/adminApi.js` as a wrapper for non-migrated features.

### Testing
- Built the migrated Admin app with `npm run build` in `clon/AdminBeneficiosFinalPublicado`, which completed successfully (vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab945e22083229fee90bb618be0a8)