### PR TITLE
Add credential/token login flows and tabbed LoginFormScreen

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/core-config/gateways.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core-config/gateways.js
@@ -5,6 +5,7 @@ import { BeneficioGatewayFetch } from "../core/infrastructure/http/BeneficioGate
 import { CategoriaGatewayFetch } from "../core/infrastructure/http/CategoriaGatewayFetch";
 import { ProveedorGatewayFetch } from "../core/infrastructure/http/ProveedorGatewayFetch";
 import { ToqueBeneficioGatewayFetch } from "../core/infrastructure/http/ToqueBeneficioGatewayFetch";
+import { AuthGatewayFetch } from "../core/infrastructure/auth/AuthGatewayFetch";
 
 const fetchClient = createFetchClient({
   baseUrl: API_BASE,
@@ -20,3 +21,8 @@ export const beneficioGateway = new BeneficioGatewayFetch(fetchClient);
 export const categoriaGateway = new CategoriaGatewayFetch(fetchClient);
 export const proveedorGateway = new ProveedorGatewayFetch(fetchClient);
 export const toqueBeneficioGateway = new ToqueBeneficioGatewayFetch(fetchClient);
+export const authGateway = new AuthGatewayFetch({
+  baseUrl: API_BASE,
+  credentialsPath: "/api/AdminAuth/login",
+  tokenPath: "/api/Proveedor/login",
+});

--- a/clon/AdminBeneficiosFinalPublicado/src/core-config/useCases.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core-config/useCases.js
@@ -1,9 +1,11 @@
 import {
+  authGateway,
   beneficioGateway,
   categoriaGateway,
   proveedorGateway,
   toqueBeneficioGateway,
 } from "./gateways";
+import { adminSessionStore } from "./sessionStores";
 import { loadBeneficiosList as loadBeneficiosListUseCase } from "../core/flujo/use-cases/LoadBeneficiosList";
 import { loadCategoriasList as loadCategoriasListUseCase } from "../core/flujo/use-cases/LoadCategoriasList";
 import { loadProveedoresList as loadProveedoresListUseCase } from "../core/flujo/use-cases/LoadProveedoresList";
@@ -13,6 +15,8 @@ import { loadToqueAnalytics as loadToqueAnalyticsUseCase } from "../core/flujo/u
 import { loadToqueSummary as loadToqueSummaryUseCase } from "../core/flujo/use-cases/LoadToqueSummary";
 import { saveBeneficio as saveBeneficioUseCase } from "../core/flujo/use-cases/SaveBeneficio";
 import { deleteBeneficio as deleteBeneficioUseCase } from "../core/flujo/use-cases/DeleteBeneficio";
+import { loginWithCredentials as loginWithCredentialsUseCase } from "../core/flujo/use-cases/LoginWithCredentials";
+import { loginWithToken as loginWithTokenUseCase } from "../core/flujo/use-cases/LoginWithToken";
 
 export const loadBeneficiosList = () =>
   loadBeneficiosListUseCase({ beneficioGateway });
@@ -48,3 +52,22 @@ export const saveBeneficio = ({ dto, editing }) =>
 
 export const deleteBeneficio = ({ beneficioId }) =>
   deleteBeneficioUseCase({ beneficioGateway, beneficioId });
+
+export const loginWithCredentials = ({ usuario, password, normalizeSession, options } = {}) =>
+  loginWithCredentialsUseCase({
+    authGateway,
+    sessionStore: adminSessionStore,
+    usuario,
+    password,
+    normalizeSession,
+    options,
+  });
+
+export const loginWithToken = ({ token, normalizeSession, options } = {}) =>
+  loginWithTokenUseCase({
+    authGateway,
+    sessionStore: adminSessionStore,
+    token,
+    normalizeSession,
+    options,
+  });

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
@@ -1,5 +1,9 @@
 export class AuthGateway {
-  async login() {
-    throw new Error("AuthGateway.login not implemented");
+  async loginWithCredentials() {
+    throw new Error("AuthGateway.loginWithCredentials not implemented");
+  }
+
+  async loginWithToken() {
+    throw new Error("AuthGateway.loginWithToken not implemented");
   }
 }

--- a/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
@@ -7,6 +7,10 @@ export class SessionStore {
     throw new Error("SessionStore.setSession not implemented");
   }
 
+  save(_session) {
+    throw new Error("SessionStore.save not implemented");
+  }
+
   clearSession() {
     throw new Error("SessionStore.clearSession not implemented");
   }

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
@@ -1,0 +1,27 @@
+export async function loginWithCredentials({
+  authGateway,
+  sessionStore,
+  usuario,
+  password,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithCredentials({
+      usuario,
+      password,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { usuario }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
@@ -1,0 +1,25 @@
+export async function loginWithToken({
+  authGateway,
+  sessionStore,
+  token,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithToken({
+      token,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { token }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
@@ -1,6 +1,8 @@
 export class AuthGatewayFetch {
-  constructor({ baseUrl = "" } = {}) {
+  constructor({ baseUrl = "", credentialsPath = "/login", tokenPath = "/login" } = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.credentialsPath = credentialsPath;
+    this.tokenPath = tokenPath;
   }
 
   async login({ path = "/login", body } = {}) {
@@ -10,14 +12,42 @@ export class AuthGatewayFetch {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
+      mode: "cors",
       body: JSON.stringify(body ?? {}),
     });
 
     if (!res.ok) {
-      throw new Error(`Login failed: ${res.status}`);
+      let message = `Login failed: ${res.status}`;
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const payload = await res.json();
+          message = payload?.mensaje || payload?.message || message;
+        } else {
+          const text = await res.text();
+          if (text) message = text;
+        }
+      } catch (error) {
+        console.error("AuthGatewayFetch login error parse", error);
+      }
+      throw new Error(message);
     }
 
     const ct = res.headers.get("content-type") || "";
     return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  async loginWithCredentials({ usuario, password, path } = {}) {
+    return this.login({
+      path: path ?? this.credentialsPath,
+      body: { usuario, password },
+    });
+  }
+
+  async loginWithToken({ token, path } = {}) {
+    return this.login({
+      path: path ?? this.tokenPath,
+      body: { token },
+    });
   }
 }

--- a/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
@@ -25,6 +25,10 @@ export class LocalSessionStore {
     }
   }
 
+  save(session) {
+    this.setSession(session);
+  }
+
   clearSession() {
     if (!this.storage) return;
     try {

--- a/clon/AdminBeneficiosFinalPublicado/src/pages/AdminLogin.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/pages/AdminLogin.jsx
@@ -1,34 +1,54 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { adminLogin } from "../services/authApi";
-import { adminSessionStore } from "../core-config/sessionStores";
+import { loginWithCredentials } from "../core-config/useCases";
 
-export default function AdminLogin() {
+export default function LoginFormScreen() {
   const navigate = useNavigate();
+  const [mode, setMode] = useState("credentials");
   const [user, setUser] = useState("");
   const [pass, setPass] = useState("");
+  const [token, setToken] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e) => {
+  const modes = useMemo(
+    () => [
+      { key: "credentials", label: "Usuario y contraseña", enabled: true },
+      { key: "token", label: "Token", enabled: false },
+    ],
+    []
+  );
+
+  const normalizeAdminSession = (data) => {
+    const profile = data?.profile || data?.user || null;
+    const roles = profile?.roles || profile?.Roles || ["Admin"];
+    const expiresAt = data?.expiresAt ?? data?.expires_at;
+    return {
+      access_token: data?.token ?? data?.access_token,
+      token_type: data?.tokenType ?? data?.token_type ?? "Bearer",
+      expires_at: expiresAt ? new Date(expiresAt).getTime() : null,
+      user: profile,
+      roles,
+    };
+  };
+
+  const handleCredentialsSubmit = async (e) => {
     e.preventDefault();
     setError("");
     setLoading(true);
 
     try {
-      const { token, expiresAt, profile } = await adminLogin({ user, pass });
-
-      const roles = profile?.roles || profile?.Roles || ["Admin"];
-
-      adminSessionStore.setSession({
-        access_token: token, // mantenemos el nombre interno para no romper el resto del admin
-        token_type: "Bearer",
-        expires_at: new Date(expiresAt).getTime(),
-        user: profile,
-        roles,
+      const result = await loginWithCredentials({
+        usuario: user,
+        password: pass,
+        normalizeSession: normalizeAdminSession,
       });
 
-      navigate("/admin", { replace: true });
+      if (!result.ok) {
+        throw result.error || new Error(result.message);
+      }
+
+      navigate("/", { replace: true });
     } catch (err) {
       if (err?.message === "Credenciales inválidas")
         setError(err.message);
@@ -40,45 +60,100 @@ export default function AdminLogin() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-white px-4">
-      <form
-        onSubmit={handleSubmit}
-        className="max-w-sm w-full space-y-4 border border-white/10 rounded-2xl p-6 bg-black/50"
-      >
+      <div className="max-w-sm w-full space-y-4 border border-white/10 rounded-2xl p-6 bg-black/50">
         <div className="space-y-1">
           <p className="text-xs uppercase tracking-wide text-white/50">Admin</p>
           <h1 className="text-2xl font-semibold">Inicio de sesión</h1>
         </div>
 
-        <div className="space-y-1">
-          <label className="text-sm text-white/70">Usuario</label>
-          <input
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-            className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
-            autoComplete="username"
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="text-sm text-white/70">Contraseña</label>
-          <input
-            type="password"
-            value={pass}
-            onChange={(e) => setPass(e.target.value)}
-            className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
-            autoComplete="current-password"
-          />
+        <div className="flex rounded-full border border-white/10 bg-neutral-900/60 p-1 text-xs">
+          {modes.map((option) => {
+            const active = mode === option.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => option.enabled && setMode(option.key)}
+                className={`flex-1 rounded-full px-3 py-2 font-semibold transition ${
+                  active ? "bg-emerald-500 text-black" : "text-white/70"
+                } ${option.enabled ? "" : "opacity-40 cursor-not-allowed"}`}
+                disabled={!option.enabled}
+              >
+                {option.label}
+              </button>
+            );
+          })}
         </div>
 
-        {error && <p className="text-sm text-red-300">{error}</p>}
+        {mode === "credentials" && (
+          <form onSubmit={handleCredentialsSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Usuario</label>
+              <input
+                value={user}
+                onChange={(e) => setUser(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="username"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Contraseña</label>
+              <input
+                type="password"
+                value={pass}
+                onChange={(e) => setPass(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="current-password"
+              />
+            </div>
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full px-4 py-2 rounded-full bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {loading ? "Ingresando..." : "Entrar"}
-        </button>
-      </form>
+            {error && <p className="text-sm text-red-300">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full px-4 py-2 rounded-full bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Ingresando..." : "Entrar"}
+            </button>
+          </form>
+        )}
+
+        {mode === "token" && (
+          <form className="space-y-4">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Token</label>
+              <input
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                placeholder="Pega tu token"
+              />
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="flex-1 px-4 py-2 rounded-full border border-white/15 text-sm text-white/70"
+                disabled
+              >
+                Scan QR
+              </button>
+              <button
+                type="submit"
+                disabled
+                className="flex-1 px-4 py-2 rounded-full bg-emerald-500 text-black font-semibold opacity-50 cursor-not-allowed"
+              >
+                Entrar
+              </button>
+            </div>
+            {token && (
+              <p className="text-xs text-white/50">
+                El acceso por token está disponible solo en el portal de proveedores.
+              </p>
+            )}
+          </form>
+        )}
+      </div>
     </div>
   );
 }

--- a/clon/BeneficiosFinalPublicado/src/core-config/gateways.js
+++ b/clon/BeneficiosFinalPublicado/src/core-config/gateways.js
@@ -7,6 +7,7 @@ import { ProveedorGatewayFetch } from "../core/infrastructure/http/ProveedorGate
 import { ToqueBeneficioGatewayFetch } from "../core/infrastructure/http/ToqueBeneficioGatewayFetch";
 import { BeneficioImagenGatewayFetch } from "../core/infrastructure/http/BeneficioImagenGatewayFetch";
 import { RifaParticipacionGatewayFetch } from "../core/infrastructure/http/RifaParticipacionGatewayFetch";
+import { AuthGatewayFetch } from "../core/infrastructure/auth/AuthGatewayFetch";
 
 const fetchClient = createFetchClient({
   baseUrl: API_BASE,
@@ -24,3 +25,8 @@ export const proveedorGateway = new ProveedorGatewayFetch(fetchClient);
 export const toqueBeneficioGateway = new ToqueBeneficioGatewayFetch(fetchClient);
 export const beneficioImagenGateway = new BeneficioImagenGatewayFetch(fetchClient);
 export const rifaParticipacionGateway = new RifaParticipacionGatewayFetch(fetchClient);
+export const authGateway = new AuthGatewayFetch({
+  baseUrl: API_BASE,
+  credentialsPath: "/api/AdminAuth/login",
+  tokenPath: "/api/Proveedor/login",
+});

--- a/clon/BeneficiosFinalPublicado/src/core-config/useCases.js
+++ b/clon/BeneficiosFinalPublicado/src/core-config/useCases.js
@@ -1,4 +1,5 @@
 import {
+  authGateway,
   beneficioGateway,
   categoriaGateway,
   proveedorGateway,
@@ -6,6 +7,7 @@ import {
   beneficioImagenGateway,
   rifaParticipacionGateway,
 } from "./gateways";
+import { clientSessionStore } from "./sessionStores";
 import { loadBeneficiosList as loadBeneficiosListUseCase } from "../core/flujo/use-cases/LoadBeneficiosList";
 import { loadCategoriasList as loadCategoriasListUseCase } from "../core/flujo/use-cases/LoadCategoriasList";
 import { loadProveedoresList as loadProveedoresListUseCase } from "../core/flujo/use-cases/LoadProveedoresList";
@@ -14,6 +16,8 @@ import { getBenefitCardImage as getBenefitCardImageUseCase } from "../core/flujo
 import { loadBeneficioImagenes as loadBeneficioImagenesUseCase } from "../core/flujo/use-cases/LoadBeneficioImagenes";
 import { registerToqueBeneficio as registerToqueBeneficioUseCase } from "../core/flujo/use-cases/RegisterToqueBeneficio";
 import { createRifaParticipacion as createRifaParticipacionUseCase } from "../core/flujo/use-cases/CreateRifaParticipacion";
+import { loginWithCredentials as loginWithCredentialsUseCase } from "../core/flujo/use-cases/LoginWithCredentials";
+import { loginWithToken as loginWithTokenUseCase } from "../core/flujo/use-cases/LoginWithToken";
 
 export const loadBeneficiosList = (options) =>
   loadBeneficiosListUseCase({ beneficioGateway, options });
@@ -38,3 +42,22 @@ export const registerToqueBeneficio = ({ beneficioId, origen, options }) =>
 
 export const createRifaParticipacion = ({ dto, options }) =>
   createRifaParticipacionUseCase({ rifaParticipacionGateway, dto, options });
+
+export const loginWithCredentials = ({ usuario, password, normalizeSession, options } = {}) =>
+  loginWithCredentialsUseCase({
+    authGateway,
+    sessionStore: clientSessionStore,
+    usuario,
+    password,
+    normalizeSession,
+    options,
+  });
+
+export const loginWithToken = ({ token, normalizeSession, options } = {}) =>
+  loginWithTokenUseCase({
+    authGateway,
+    sessionStore: clientSessionStore,
+    token,
+    normalizeSession,
+    options,
+  });

--- a/clon/BeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
+++ b/clon/BeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
@@ -1,5 +1,9 @@
 export class AuthGateway {
-  async login() {
-    throw new Error("AuthGateway.login not implemented");
+  async loginWithCredentials() {
+    throw new Error("AuthGateway.loginWithCredentials not implemented");
+  }
+
+  async loginWithToken() {
+    throw new Error("AuthGateway.loginWithToken not implemented");
   }
 }

--- a/clon/BeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
+++ b/clon/BeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
@@ -7,6 +7,10 @@ export class SessionStore {
     throw new Error("SessionStore.setSession not implemented");
   }
 
+  save(_session) {
+    throw new Error("SessionStore.save not implemented");
+  }
+
   clearSession() {
     throw new Error("SessionStore.clearSession not implemented");
   }

--- a/clon/BeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
+++ b/clon/BeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
@@ -1,0 +1,27 @@
+export async function loginWithCredentials({
+  authGateway,
+  sessionStore,
+  usuario,
+  password,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithCredentials({
+      usuario,
+      password,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { usuario }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/BeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
+++ b/clon/BeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
@@ -1,0 +1,25 @@
+export async function loginWithToken({
+  authGateway,
+  sessionStore,
+  token,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithToken({
+      token,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { token }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/BeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
+++ b/clon/BeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
@@ -1,6 +1,8 @@
 export class AuthGatewayFetch {
-  constructor({ baseUrl = "" } = {}) {
+  constructor({ baseUrl = "", credentialsPath = "/login", tokenPath = "/login" } = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.credentialsPath = credentialsPath;
+    this.tokenPath = tokenPath;
   }
 
   async login({ path = "/login", body } = {}) {
@@ -10,14 +12,42 @@ export class AuthGatewayFetch {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
+      mode: "cors",
       body: JSON.stringify(body ?? {}),
     });
 
     if (!res.ok) {
-      throw new Error(`Login failed: ${res.status}`);
+      let message = `Login failed: ${res.status}`;
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const payload = await res.json();
+          message = payload?.mensaje || payload?.message || message;
+        } else {
+          const text = await res.text();
+          if (text) message = text;
+        }
+      } catch (error) {
+        console.error("AuthGatewayFetch login error parse", error);
+      }
+      throw new Error(message);
     }
 
     const ct = res.headers.get("content-type") || "";
     return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  async loginWithCredentials({ usuario, password, path } = {}) {
+    return this.login({
+      path: path ?? this.credentialsPath,
+      body: { usuario, password },
+    });
+  }
+
+  async loginWithToken({ token, path } = {}) {
+    return this.login({
+      path: path ?? this.tokenPath,
+      body: { token },
+    });
   }
 }

--- a/clon/BeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
+++ b/clon/BeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
@@ -25,6 +25,10 @@ export class LocalSessionStore {
     }
   }
 
+  save(session) {
+    this.setSession(session);
+  }
+
   clearSession() {
     if (!this.storage) return;
     try {

--- a/clon/BeneficiosFinalPublicado/src/pages/ClientLogin.jsx
+++ b/clon/BeneficiosFinalPublicado/src/pages/ClientLogin.jsx
@@ -1,24 +1,53 @@
-import { useEffect } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { clientSessionStore } from "../core-config/sessionStores";
+import { loginWithCredentials } from "../core-config/useCases";
 
-export default function ClientLogin() {
+export default function LoginFormScreen() {
   const navigate = useNavigate();
+  const [mode, setMode] = useState("credentials");
+  const [usuario, setUsuario] = useState("");
+  const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    const session = clientSessionStore.getSession();
-    if (session?.token) {
+  const modes = useMemo(
+    () => [
+      { key: "credentials", label: "Usuario y contraseña", enabled: true },
+      { key: "token", label: "Token", enabled: false },
+    ],
+    []
+  );
+
+  const normalizeClientSession = (data) => ({
+    token: data?.token ?? data?.access_token ?? "client-session",
+    tsLogin: Date.now(),
+    roles: data?.roles || data?.profile?.roles || ["Client"],
+    user: data?.profile ?? data?.user ?? null,
+  });
+
+  const handleCredentialsSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const result = await loginWithCredentials({
+        usuario,
+        password,
+        normalizeSession: normalizeClientSession,
+      });
+
+      if (!result.ok) {
+        throw result.error || new Error(result.message);
+      }
+
       navigate("/", { replace: true });
+    } catch (err) {
+      setError(err?.message || "No se pudo iniciar sesión");
+    } finally {
+      setLoading(false);
     }
-  }, [navigate]);
-
-  const handleContinue = () => {
-    clientSessionStore.setSession({
-      token: "client-session",
-      tsLogin: Date.now(),
-      roles: ["Client"],
-    });
-    navigate("/", { replace: true });
   };
 
   return (
@@ -28,12 +57,93 @@ export default function ClientLogin() {
         <p className="text-sm text-white/70">
           Ingresa para explorar los beneficios disponibles.
         </p>
-        <button
-          onClick={handleContinue}
-          className="px-4 py-2 rounded-full bg-white text-black font-semibold hover:bg-white/90"
-        >
-          Continuar
-        </button>
+        <div className="flex rounded-full border border-white/10 bg-white/5 p-1 text-xs">
+          {modes.map((option) => {
+            const active = mode === option.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => option.enabled && setMode(option.key)}
+                className={`flex-1 rounded-full px-3 py-2 font-semibold transition ${
+                  active ? "bg-white text-black" : "text-white/70"
+                } ${option.enabled ? "" : "opacity-40 cursor-not-allowed"}`}
+                disabled={!option.enabled}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {mode === "credentials" && (
+          <form onSubmit={handleCredentialsSubmit} className="space-y-4 text-left">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Usuario</label>
+              <input
+                value={usuario}
+                onChange={(e) => setUsuario(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="username"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Contraseña</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && <p className="text-sm text-red-300 text-center">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full px-4 py-2 rounded-full bg-white text-black font-semibold hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Ingresando..." : "Entrar"}
+            </button>
+          </form>
+        )}
+
+        {mode === "token" && (
+          <form className="space-y-4 text-left">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Token</label>
+              <input
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                placeholder="Pega tu token"
+              />
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="flex-1 px-4 py-2 rounded-full border border-white/15 text-sm text-white/70"
+                disabled
+              >
+                Scan QR
+              </button>
+              <button
+                type="submit"
+                disabled
+                className="flex-1 px-4 py-2 rounded-full bg-white text-black font-semibold opacity-50 cursor-not-allowed"
+              >
+                Entrar
+              </button>
+            </div>
+            {token && (
+              <p className="text-xs text-white/50 text-center">
+                El acceso por token está disponible solo en el portal de proveedores.
+              </p>
+            )}
+          </form>
+        )}
       </div>
     </div>
   );

--- a/clon/InicioBeneficiosFinalPublicado/src/core-config/gateways.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core-config/gateways.js
@@ -8,6 +8,7 @@ import { ToqueBeneficioGatewayFetch } from "../core/infrastructure/http/ToqueBen
 import { BeneficioImagenGatewayFetch } from "../core/infrastructure/http/BeneficioImagenGatewayFetch";
 import { RifaParticipacionGatewayFetch } from "../core/infrastructure/http/RifaParticipacionGatewayFetch";
 import { ContactoGatewayFetch } from "../core/infrastructure/http/ContactoGatewayFetch";
+import { AuthGatewayFetch } from "../core/infrastructure/auth/AuthGatewayFetch";
 
 const fetchClient = createFetchClient({
   baseUrl: API_BASE,
@@ -26,3 +27,8 @@ export const toqueBeneficioGateway = new ToqueBeneficioGatewayFetch(fetchClient)
 export const beneficioImagenGateway = new BeneficioImagenGatewayFetch(fetchClient);
 export const rifaParticipacionGateway = new RifaParticipacionGatewayFetch(fetchClient);
 export const contactoGateway = new ContactoGatewayFetch();
+export const authGateway = new AuthGatewayFetch({
+  baseUrl: API_BASE,
+  credentialsPath: "/api/AdminAuth/login",
+  tokenPath: "/api/Proveedor/login",
+});

--- a/clon/InicioBeneficiosFinalPublicado/src/core-config/useCases.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core-config/useCases.js
@@ -1,4 +1,5 @@
 import {
+  authGateway,
   beneficioGateway,
   categoriaGateway,
   proveedorGateway,
@@ -7,6 +8,7 @@ import {
   rifaParticipacionGateway,
   contactoGateway,
 } from "./gateways";
+import { landingSessionStore } from "./sessionStores";
 import { loadBeneficiosList as loadBeneficiosListUseCase } from "../core/flujo/use-cases/LoadBeneficiosList";
 import { loadCategoriasList as loadCategoriasListUseCase } from "../core/flujo/use-cases/LoadCategoriasList";
 import { loadProveedoresList as loadProveedoresListUseCase } from "../core/flujo/use-cases/LoadProveedoresList";
@@ -16,6 +18,8 @@ import { loadBeneficioImagenes as loadBeneficioImagenesUseCase } from "../core/f
 import { registerToqueBeneficio as registerToqueBeneficioUseCase } from "../core/flujo/use-cases/RegisterToqueBeneficio";
 import { createRifaParticipacion as createRifaParticipacionUseCase } from "../core/flujo/use-cases/CreateRifaParticipacion";
 import { submitContacto as submitContactoUseCase } from "../core/flujo/use-cases/SubmitContacto";
+import { loginWithCredentials as loginWithCredentialsUseCase } from "../core/flujo/use-cases/LoginWithCredentials";
+import { loginWithToken as loginWithTokenUseCase } from "../core/flujo/use-cases/LoginWithToken";
 
 export const loadBeneficiosList = (options) =>
   loadBeneficiosListUseCase({ beneficioGateway, options });
@@ -43,3 +47,22 @@ export const createRifaParticipacion = ({ dto, options }) =>
 
 export const submitContacto = ({ url, dto, options }) =>
   submitContactoUseCase({ contactoGateway, url, dto, options });
+
+export const loginWithCredentials = ({ usuario, password, normalizeSession, options } = {}) =>
+  loginWithCredentialsUseCase({
+    authGateway,
+    sessionStore: landingSessionStore,
+    usuario,
+    password,
+    normalizeSession,
+    options,
+  });
+
+export const loginWithToken = ({ token, normalizeSession, options } = {}) =>
+  loginWithTokenUseCase({
+    authGateway,
+    sessionStore: landingSessionStore,
+    token,
+    normalizeSession,
+    options,
+  });

--- a/clon/InicioBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
@@ -1,5 +1,9 @@
 export class AuthGateway {
-  async login() {
-    throw new Error("AuthGateway.login not implemented");
+  async loginWithCredentials() {
+    throw new Error("AuthGateway.loginWithCredentials not implemented");
+  }
+
+  async loginWithToken() {
+    throw new Error("AuthGateway.loginWithToken not implemented");
   }
 }

--- a/clon/InicioBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
@@ -7,6 +7,10 @@ export class SessionStore {
     throw new Error("SessionStore.setSession not implemented");
   }
 
+  save(_session) {
+    throw new Error("SessionStore.save not implemented");
+  }
+
   clearSession() {
     throw new Error("SessionStore.clearSession not implemented");
   }

--- a/clon/InicioBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
@@ -1,0 +1,27 @@
+export async function loginWithCredentials({
+  authGateway,
+  sessionStore,
+  usuario,
+  password,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithCredentials({
+      usuario,
+      password,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { usuario }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/InicioBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
@@ -1,0 +1,25 @@
+export async function loginWithToken({
+  authGateway,
+  sessionStore,
+  token,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithToken({
+      token,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { token }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/InicioBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
@@ -1,6 +1,8 @@
 export class AuthGatewayFetch {
-  constructor({ baseUrl = "" } = {}) {
+  constructor({ baseUrl = "", credentialsPath = "/login", tokenPath = "/login" } = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.credentialsPath = credentialsPath;
+    this.tokenPath = tokenPath;
   }
 
   async login({ path = "/login", body } = {}) {
@@ -10,14 +12,42 @@ export class AuthGatewayFetch {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
+      mode: "cors",
       body: JSON.stringify(body ?? {}),
     });
 
     if (!res.ok) {
-      throw new Error(`Login failed: ${res.status}`);
+      let message = `Login failed: ${res.status}`;
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const payload = await res.json();
+          message = payload?.mensaje || payload?.message || message;
+        } else {
+          const text = await res.text();
+          if (text) message = text;
+        }
+      } catch (error) {
+        console.error("AuthGatewayFetch login error parse", error);
+      }
+      throw new Error(message);
     }
 
     const ct = res.headers.get("content-type") || "";
     return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  async loginWithCredentials({ usuario, password, path } = {}) {
+    return this.login({
+      path: path ?? this.credentialsPath,
+      body: { usuario, password },
+    });
+  }
+
+  async loginWithToken({ token, path } = {}) {
+    return this.login({
+      path: path ?? this.tokenPath,
+      body: { token },
+    });
   }
 }

--- a/clon/InicioBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
+++ b/clon/InicioBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
@@ -25,6 +25,10 @@ export class LocalSessionStore {
     }
   }
 
+  save(session) {
+    this.setSession(session);
+  }
+
   clearSession() {
     if (!this.storage) return;
     try {

--- a/clon/InicioBeneficiosFinalPublicado/src/pages/LandingLogin.jsx
+++ b/clon/InicioBeneficiosFinalPublicado/src/pages/LandingLogin.jsx
@@ -1,23 +1,53 @@
-import { useEffect } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { landingSessionStore } from "../core-config/sessionStores";
+import { loginWithCredentials } from "../core-config/useCases";
 
-export default function LandingLogin() {
+export default function LoginFormScreen() {
   const navigate = useNavigate();
+  const [mode, setMode] = useState("credentials");
+  const [usuario, setUsuario] = useState("");
+  const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    const session = landingSessionStore.getSession();
-    if (session?.token) {
+  const modes = useMemo(
+    () => [
+      { key: "credentials", label: "Usuario y contraseña", enabled: true },
+      { key: "token", label: "Token", enabled: false },
+    ],
+    []
+  );
+
+  const normalizeLandingSession = (data) => ({
+    token: data?.token ?? data?.access_token ?? "landing-session",
+    tsLogin: Date.now(),
+    roles: data?.roles || data?.profile?.roles || [],
+    user: data?.profile ?? data?.user ?? null,
+  });
+
+  const handleCredentialsSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const result = await loginWithCredentials({
+        usuario,
+        password,
+        normalizeSession: normalizeLandingSession,
+      });
+
+      if (!result.ok) {
+        throw result.error || new Error(result.message);
+      }
+
       navigate("/", { replace: true });
+    } catch (err) {
+      setError(err?.message || "No se pudo iniciar sesión");
+    } finally {
+      setLoading(false);
     }
-  }, [navigate]);
-
-  const handleContinue = () => {
-    landingSessionStore.setSession({
-      token: "landing-session",
-      tsLogin: Date.now(),
-    });
-    navigate("/", { replace: true });
   };
 
   return (
@@ -27,12 +57,93 @@ export default function LandingLogin() {
         <p className="text-sm text-white/70">
           Ingresa para explorar las opciones de acceso de HR Beneficios.
         </p>
-        <button
-          onClick={handleContinue}
-          className="px-4 py-2 rounded-full bg-white text-black font-semibold hover:bg-white/90"
-        >
-          Continuar
-        </button>
+        <div className="flex rounded-full border border-white/10 bg-white/5 p-1 text-xs">
+          {modes.map((option) => {
+            const active = mode === option.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => option.enabled && setMode(option.key)}
+                className={`flex-1 rounded-full px-3 py-2 font-semibold transition ${
+                  active ? "bg-white text-black" : "text-white/70"
+                } ${option.enabled ? "" : "opacity-40 cursor-not-allowed"}`}
+                disabled={!option.enabled}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {mode === "credentials" && (
+          <form onSubmit={handleCredentialsSubmit} className="space-y-4 text-left">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Usuario</label>
+              <input
+                value={usuario}
+                onChange={(e) => setUsuario(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="username"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Contraseña</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && <p className="text-sm text-red-300 text-center">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full px-4 py-2 rounded-full bg-white text-black font-semibold hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Ingresando..." : "Entrar"}
+            </button>
+          </form>
+        )}
+
+        {mode === "token" && (
+          <form className="space-y-4 text-left">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Token</label>
+              <input
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                placeholder="Pega tu token"
+              />
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="flex-1 px-4 py-2 rounded-full border border-white/15 text-sm text-white/70"
+                disabled
+              >
+                Scan QR
+              </button>
+              <button
+                type="submit"
+                disabled
+                className="flex-1 px-4 py-2 rounded-full bg-white text-black font-semibold opacity-50 cursor-not-allowed"
+              >
+                Entrar
+              </button>
+            </div>
+            {token && (
+              <p className="text-xs text-white/50 text-center">
+                El acceso por token está disponible solo en el portal de proveedores.
+              </p>
+            )}
+          </form>
+        )}
       </div>
     </div>
   );

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core-config/gateways.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core-config/gateways.js
@@ -5,6 +5,7 @@ import { BeneficioGatewayFetch } from "../core/infrastructure/http/BeneficioGate
 import { CategoriaGatewayFetch } from "../core/infrastructure/http/CategoriaGatewayFetch";
 import { ProveedorGatewayFetch } from "../core/infrastructure/http/ProveedorGatewayFetch";
 import { BeneficioImagenGatewayFetch } from "../core/infrastructure/http/BeneficioImagenGatewayFetch";
+import { AuthGatewayFetch } from "../core/infrastructure/auth/AuthGatewayFetch";
 
 const fetchClient = createFetchClient({
   baseUrl: API_BASE,
@@ -20,3 +21,8 @@ export const beneficioGateway = new BeneficioGatewayFetch(fetchClient);
 export const categoriaGateway = new CategoriaGatewayFetch(fetchClient);
 export const proveedorGateway = new ProveedorGatewayFetch(fetchClient);
 export const beneficioImagenGateway = new BeneficioImagenGatewayFetch(fetchClient);
+export const authGateway = new AuthGatewayFetch({
+  baseUrl: API_BASE,
+  credentialsPath: "/api/AdminAuth/login",
+  tokenPath: "/api/Proveedor/login",
+});

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core-config/useCases.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core-config/useCases.js
@@ -1,9 +1,11 @@
 import {
+  authGateway,
   beneficioGateway,
   categoriaGateway,
   proveedorGateway,
   beneficioImagenGateway,
 } from "./gateways";
+import { providerSessionStore } from "./sessionStores";
 import { loadBeneficiosList as loadBeneficiosListUseCase } from "../core/flujo/use-cases/LoadBeneficiosList";
 import { loadBeneficiosByProveedor as loadBeneficiosByProveedorUseCase } from "../core/flujo/use-cases/LoadBeneficiosByProveedor";
 import { loadCategoriasList as loadCategoriasListUseCase } from "../core/flujo/use-cases/LoadCategoriasList";
@@ -23,6 +25,8 @@ import { approveBeneficio as approveBeneficioUseCase } from "../core/flujo/use-c
 import { rejectBeneficio as rejectBeneficioUseCase } from "../core/flujo/use-cases/RejectBeneficio";
 import { setBeneficioDisponible as setBeneficioDisponibleUseCase } from "../core/flujo/use-cases/SetBeneficioDisponible";
 import { validateProveedorLogin as validateProveedorLoginUseCase } from "../core/flujo/use-cases/ValidateProveedorLogin";
+import { loginWithCredentials as loginWithCredentialsUseCase } from "../core/flujo/use-cases/LoginWithCredentials";
+import { loginWithToken as loginWithTokenUseCase } from "../core/flujo/use-cases/LoginWithToken";
 
 export const loadBeneficiosList = (options) =>
   loadBeneficiosListUseCase({ beneficioGateway, options });
@@ -80,3 +84,22 @@ export const setBeneficioDisponible = ({ beneficioId, disponible, options }) =>
 
 export const validateProveedorLogin = (proveedorId, options) =>
   validateProveedorLoginUseCase({ proveedorGateway, proveedorId, options });
+
+export const loginWithCredentials = ({ usuario, password, normalizeSession, options } = {}) =>
+  loginWithCredentialsUseCase({
+    authGateway,
+    sessionStore: providerSessionStore,
+    usuario,
+    password,
+    normalizeSession,
+    options,
+  });
+
+export const loginWithToken = ({ token, normalizeSession, options } = {}) =>
+  loginWithTokenUseCase({
+    authGateway,
+    sessionStore: providerSessionStore,
+    token,
+    normalizeSession,
+    options,
+  });

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/abstracciones/gateways/AuthGateway.js
@@ -1,5 +1,9 @@
 export class AuthGateway {
-  async login() {
-    throw new Error("AuthGateway.login not implemented");
+  async loginWithCredentials() {
+    throw new Error("AuthGateway.loginWithCredentials not implemented");
+  }
+
+  async loginWithToken() {
+    throw new Error("AuthGateway.loginWithToken not implemented");
   }
 }

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/abstracciones/stores/SessionStore.js
@@ -7,6 +7,10 @@ export class SessionStore {
     throw new Error("SessionStore.setSession not implemented");
   }
 
+  save(_session) {
+    throw new Error("SessionStore.save not implemented");
+  }
+
   clearSession() {
     throw new Error("SessionStore.clearSession not implemented");
   }

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithCredentials.js
@@ -1,0 +1,27 @@
+export async function loginWithCredentials({
+  authGateway,
+  sessionStore,
+  usuario,
+  password,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithCredentials({
+      usuario,
+      password,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { usuario }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/flujo/use-cases/LoginWithToken.js
@@ -1,0 +1,25 @@
+export async function loginWithToken({
+  authGateway,
+  sessionStore,
+  token,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithToken({
+      token,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { token }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/infrastructure/auth/AuthGatewayFetch.js
@@ -1,6 +1,8 @@
 export class AuthGatewayFetch {
-  constructor({ baseUrl = "" } = {}) {
+  constructor({ baseUrl = "", credentialsPath = "/login", tokenPath = "/login" } = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.credentialsPath = credentialsPath;
+    this.tokenPath = tokenPath;
   }
 
   async login({ path = "/login", body } = {}) {
@@ -10,14 +12,42 @@ export class AuthGatewayFetch {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
+      mode: "cors",
       body: JSON.stringify(body ?? {}),
     });
 
     if (!res.ok) {
-      throw new Error(`Login failed: ${res.status}`);
+      let message = `Login failed: ${res.status}`;
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const payload = await res.json();
+          message = payload?.mensaje || payload?.message || message;
+        } else {
+          const text = await res.text();
+          if (text) message = text;
+        }
+      } catch (error) {
+        console.error("AuthGatewayFetch login error parse", error);
+      }
+      throw new Error(message);
     }
 
     const ct = res.headers.get("content-type") || "";
     return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  async loginWithCredentials({ usuario, password, path } = {}) {
+    return this.login({
+      path: path ?? this.credentialsPath,
+      body: { usuario, password },
+    });
+  }
+
+  async loginWithToken({ token, path } = {}) {
+    return this.login({
+      path: path ?? this.tokenPath,
+      body: { token },
+    });
   }
 }

--- a/clon/ProveedorBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/core/infrastructure/session/LocalSessionStore.js
@@ -25,6 +25,10 @@ export class LocalSessionStore {
     }
   }
 
+  save(session) {
+    this.setSession(session);
+  }
+
   clearSession() {
     if (!this.storage) return;
     try {

--- a/clon/ProveedorBeneficiosFinalPublicado/src/proveedor/pages/ProveedorLogin.jsx
+++ b/clon/ProveedorBeneficiosFinalPublicado/src/proveedor/pages/ProveedorLogin.jsx
@@ -1,128 +1,138 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { validateProveedorLogin } from "../../core-config/useCases";
-import { providerSessionStore } from "../../core-config/sessionStores";
+import { loginWithToken } from "../../core-config/useCases";
 
-const guidRegex = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-
-export default function ProveedorLogin() {
+export default function LoginFormScreen() {
   const navigate = useNavigate();
-  const [estado, setEstado] = useState("checking");
-  const [mensaje, setMensaje] = useState("Validando tu código QR…");
+  const [mode, setMode] = useState("token");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const modes = useMemo(
+    () => [
+      { key: "credentials", label: "Usuario y contraseña", enabled: false },
+      { key: "token", label: "Token", enabled: true },
+    ],
+    []
+  );
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const proveedorId = params.get("proveedorId");
-    const token = params.get("token");
-
-    if (!proveedorId || !guidRegex.test(proveedorId)) {
-      setEstado("error");
-      setMensaje(
-        "El enlace de acceso es inválido. Pide un nuevo código QR al administrador."
-      );
-      return;
+    const incomingToken = params.get("token");
+    if (incomingToken) {
+      setToken(incomingToken);
     }
+  }, []);
 
-    const validarProveedor = async () => {
-      try {
-        setMensaje("Validando tu código QR…");
-        const resp = await validateProveedorLogin(proveedorId);
+  const normalizeProveedorSession = (data, { token: rawToken }) => {
+    const proveedor = data?.proveedor ?? data?.Proveedor ?? data?.provider ?? null;
+    const proveedorId =
+      proveedor?.proveedorId || proveedor?.ProveedorId || proveedor?.id || proveedor?.Id;
+    const proveedorNombre =
+      proveedor?.nombre || proveedor?.Nombre || proveedor?.titulo || proveedor?.Titulo;
 
-        if (resp?.ok) {
-          providerSessionStore.setSession({
-            proveedorId,
-            token,
-            roles: ["Proveedor"],
-          });
-          setEstado("ok");
-          setMensaje(resp?.mensaje || "Proveedor válido. Redirigiendo…");
-
-          setTimeout(() => {
-            navigate("/", { replace: true });
-          }, 1000);
-        } else {
-          setEstado("error");
-          setMensaje(resp?.mensaje || "QR inválido o proveedor no encontrado.");
-        }
-      } catch (error) {
-        console.error("[ProveedorLogin] Error validando proveedor", error);
-        setEstado("error");
-        setMensaje(
-          "No pudimos validar tu acceso. Intenta nuevamente o solicita un nuevo QR."
-        );
-      }
+    return {
+      proveedorId,
+      proveedorNombre,
+      token: rawToken,
+      roles: ["Proveedor"],
+      tsLogin: Date.now(),
+      user: proveedor ?? null,
     };
-
-    validarProveedor();
-  }, [navigate]);
-
-  const statusStyles = {
-    checking: "text-neutral-300",
-    ok: "text-emerald-400",
-    error: "text-red-400",
   };
 
-  const secondaryText =
-    estado === "error"
-      ? "Verifica que el QR sea el más reciente o solicita uno nuevo al administrador."
-      : "";
+  const handleTokenSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const result = await loginWithToken({
+        token,
+        normalizeSession: normalizeProveedorSession,
+      });
+
+      if (!result.ok || !result.session?.proveedorId) {
+        throw result.error || new Error(result.message || "Token inválido.");
+      }
+
+      navigate("/", { replace: true });
+    } catch (err) {
+      setError(err?.message || "No pudimos validar tu acceso.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-neutral-950 text-white flex items-center justify-center p-6">
       <div className="w-full max-w-lg bg-neutral-900 border border-white/10 rounded-2xl shadow-lg p-8 space-y-6">
         <div className="space-y-2 text-center">
-          <p className="text-xs uppercase tracking-[0.3em] text-emerald-400/80">Portal Proveedores</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-emerald-400/80">
+            Portal Proveedores
+          </p>
           <h1 className="text-3xl font-bold">Acceso de Proveedores</h1>
           <p className="text-sm text-neutral-400">
-            {estado === "checking"
-              ? "Estamos validando tu código QR…"
-              : estado === "ok"
-              ? "Proveedor válido. Redirigiendo…"
-              : "El enlace no es válido o expiró."}
+            Ingresa con tu token de acceso o escanea tu QR.
           </p>
         </div>
 
-        <div className="flex items-center justify-center">
-          {estado === "checking" && (
-            <div className="h-12 w-12 rounded-full border-2 border-emerald-400/70 border-t-transparent animate-spin" />
-          )}
-          {estado === "ok" && (
-            <div className="h-12 w-12 rounded-full flex items-center justify-center bg-emerald-500/10 border border-emerald-500/50 text-emerald-400">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="h-6 w-6"
+        <div className="flex rounded-full border border-white/10 bg-neutral-950/60 p-1 text-xs">
+          {modes.map((option) => {
+            const active = mode === option.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => option.enabled && setMode(option.key)}
+                className={`flex-1 rounded-full px-3 py-2 font-semibold transition ${
+                  active ? "bg-emerald-500 text-black" : "text-white/70"
+                } ${option.enabled ? "" : "opacity-40 cursor-not-allowed"}`}
+                disabled={!option.enabled}
               >
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-            </div>
-          )}
-          {estado === "error" && (
-            <div className="h-12 w-12 rounded-full flex items-center justify-center bg-red-500/10 border border-red-500/50 text-red-400">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="h-6 w-6"
-              >
-                <path d="M12 9v4m0 4h.01" />
-                <circle cx="12" cy="12" r="9" />
-              </svg>
-            </div>
-          )}
+                {option.label}
+              </button>
+            );
+          })}
         </div>
 
-        <div className={`text-center text-base font-medium ${statusStyles[estado]}`}>
-          {mensaje}
-        </div>
+        {mode === "token" && (
+          <form onSubmit={handleTokenSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Token</label>
+              <input
+                value={token}
+                onChange={(event) => setToken(event.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                placeholder="Pega tu token"
+              />
+            </div>
 
-        {secondaryText && (
-          <p className="text-center text-sm text-neutral-500 leading-relaxed">{secondaryText}</p>
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                className="w-full px-4 py-2 rounded-full border border-white/15 text-sm text-white/70"
+                disabled
+              >
+                Scan QR
+              </button>
+              <button
+                type="submit"
+                disabled={loading || !token}
+                className="w-full px-4 py-2 rounded-full bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? "Validando..." : "Entrar"}
+              </button>
+            </div>
+            {error && <p className="text-sm text-red-300 text-center">{error}</p>}
+          </form>
+        )}
+
+        {mode === "credentials" && (
+          <div className="text-center text-sm text-neutral-500">
+            El acceso con usuario y contraseña está disponible solo para administradores.
+          </div>
         )}
       </div>
     </div>

--- a/frontend-core/abstracciones/gateways/AuthGateway.js
+++ b/frontend-core/abstracciones/gateways/AuthGateway.js
@@ -1,5 +1,9 @@
 export class AuthGateway {
-  async login() {
-    throw new Error("AuthGateway.login not implemented");
+  async loginWithCredentials() {
+    throw new Error("AuthGateway.loginWithCredentials not implemented");
+  }
+
+  async loginWithToken() {
+    throw new Error("AuthGateway.loginWithToken not implemented");
   }
 }

--- a/frontend-core/abstracciones/stores/SessionStore.js
+++ b/frontend-core/abstracciones/stores/SessionStore.js
@@ -7,6 +7,10 @@ export class SessionStore {
     throw new Error("SessionStore.setSession not implemented");
   }
 
+  save(_session) {
+    throw new Error("SessionStore.save not implemented");
+  }
+
   clearSession() {
     throw new Error("SessionStore.clearSession not implemented");
   }

--- a/frontend-core/flujo/use-cases/LoginWithCredentials.js
+++ b/frontend-core/flujo/use-cases/LoginWithCredentials.js
@@ -1,0 +1,27 @@
+export async function loginWithCredentials({
+  authGateway,
+  sessionStore,
+  usuario,
+  password,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithCredentials({
+      usuario,
+      password,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { usuario }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/frontend-core/flujo/use-cases/LoginWithToken.js
+++ b/frontend-core/flujo/use-cases/LoginWithToken.js
@@ -1,0 +1,25 @@
+export async function loginWithToken({
+  authGateway,
+  sessionStore,
+  token,
+  normalizeSession,
+  options,
+} = {}) {
+  try {
+    const data = await authGateway.loginWithToken({
+      token,
+      ...(options || {}),
+    });
+    const session = normalizeSession ? normalizeSession(data, { token }) : data?.session ?? data;
+
+    if (sessionStore?.save) {
+      sessionStore.save(session);
+    } else {
+      sessionStore?.setSession?.(session);
+    }
+
+    return { ok: true, session, data };
+  } catch (error) {
+    return { ok: false, error, message: error?.message };
+  }
+}

--- a/frontend-core/infrastructure/auth/AuthGatewayFetch.js
+++ b/frontend-core/infrastructure/auth/AuthGatewayFetch.js
@@ -1,6 +1,8 @@
 export class AuthGatewayFetch {
-  constructor({ baseUrl = "" } = {}) {
+  constructor({ baseUrl = "", credentialsPath = "/login", tokenPath = "/login" } = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.credentialsPath = credentialsPath;
+    this.tokenPath = tokenPath;
   }
 
   async login({ path = "/login", body } = {}) {
@@ -10,14 +12,42 @@ export class AuthGatewayFetch {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
+      mode: "cors",
       body: JSON.stringify(body ?? {}),
     });
 
     if (!res.ok) {
-      throw new Error(`Login failed: ${res.status}`);
+      let message = `Login failed: ${res.status}`;
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const payload = await res.json();
+          message = payload?.mensaje || payload?.message || message;
+        } else {
+          const text = await res.text();
+          if (text) message = text;
+        }
+      } catch (error) {
+        console.error("AuthGatewayFetch login error parse", error);
+      }
+      throw new Error(message);
     }
 
     const ct = res.headers.get("content-type") || "";
     return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  async loginWithCredentials({ usuario, password, path } = {}) {
+    return this.login({
+      path: path ?? this.credentialsPath,
+      body: { usuario, password },
+    });
+  }
+
+  async loginWithToken({ token, path } = {}) {
+    return this.login({
+      path: path ?? this.tokenPath,
+      body: { token },
+    });
   }
 }

--- a/frontend-core/infrastructure/session/LocalSessionStore.js
+++ b/frontend-core/infrastructure/session/LocalSessionStore.js
@@ -25,6 +25,10 @@ export class LocalSessionStore {
     }
   }
 
+  save(session) {
+    this.setSession(session);
+  }
+
   clearSession() {
     if (!this.storage) return;
     try {


### PR DESCRIPTION
### Motivation
- Support two authentication methods (credentials and token/QR) while preserving Clean Architecture boundaries. 
- Keep UI free of direct `fetch`/`localStorage` access and route all auth through flow use-cases and gateway/store abstractions. 
- Provide a single LoginFormScreen UI that can be used across apps (Admin/Client/Landing/Provider) with a credentials vs token toggle. 
- Make session persistence consistent via a `save` helper on `SessionStore` implementations.

### Description
- Added `loginWithCredentials` and `loginWithToken` use-cases in `frontend-core` and copied them into each app, and wired them from each app's `core-config/useCases.js`. 
- Extended `AuthGateway` abstraction and implemented `loginWithCredentials`/`loginWithToken` in `AuthGatewayFetch`, added `credentialsPath`/`tokenPath` config and improved error parsing. 
- Added `save` to `SessionStore` abstraction and implemented `save` in `LocalSessionStore`, and updated use-cases to call `sessionStore.save(session)` (falling back to `setSession`). 
- Replaced the individual login pages with a tabbed `LoginFormScreen` in each app that supports credential form and token form (token QR scan button left as a disabled placeholder), and on success navigates to `/` so the app `Gate` decides access.

### Testing
- Ran `npm run build` in `clon/AdminBeneficiosFinalPublicado` and it succeeded. 
- Ran `npm run build` in `clon/BeneficiosFinalPublicado` and it succeeded. 
- Ran `npm run build` in `clon/InicioBeneficiosFinalPublicado` and it failed due to an unrelated missing `./api` import in `src/services/infoBoardService.js`. 
- Ran `npm run build` in `clon/ProveedorBeneficiosFinalPublicado` and it failed due to unrelated missing exports (`extractImage`/`EMBED_PLACEHOLDER`) in `src/utils/images.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aec51cfec8322ab7aa6c3da7d0d9d)