### PR TITLE
Enable token login mode and portal redirects

### DIFF
--- a/clon/InicioBeneficiosFinalPublicado/src/pages/LoginFormScreen.jsx
+++ b/clon/InicioBeneficiosFinalPublicado/src/pages/LoginFormScreen.jsx
@@ -2,17 +2,94 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   loginWithCredentials,
+  loginWithToken,
   validateSessionAndAuthorize,
 } from "../core-config/useCases";
 
+const TARGET = import.meta.env.VITE_PORTAL_TARGET || "local";
+
+const PORTAL_BASES = {
+  local: {
+    colaboradores: import.meta.env.VITE_CLIENT_PORTAL_BASE_LOCAL || "http://localhost:5173",
+    proveedores: import.meta.env.VITE_PROV_PORTAL_BASE_LOCAL || "http://localhost:5173",
+    admin: import.meta.env.VITE_ADMIN_PORTAL_BASE_LOCAL || "http://localhost:5174",
+  },
+  cloud: {
+    colaboradores: import.meta.env.VITE_CLIENT_PORTAL_BASE_CLOUD,
+    proveedores: import.meta.env.VITE_PROV_PORTAL_BASE_CLOUD,
+    admin: import.meta.env.VITE_ADMIN_PORTAL_BASE_CLOUD,
+  },
+};
+
+const normalizeRole = (role) => String(role || "").trim().toLowerCase();
+
+const getSessionRoles = (session) =>
+  session?.roles ||
+  session?.user?.roles ||
+  session?.user?.Roles ||
+  session?.user?.perfil?.roles ||
+  [];
+
+const resolvePortalKey = (session) => {
+  const roles = getSessionRoles(session).map(normalizeRole);
+
+  if (roles.some((role) => ["admin", "administrator", "administrador"].includes(role))) {
+    return "admin";
+  }
+
+  if (
+    roles.some((role) => ["proveedor", "provider"].includes(role)) ||
+    session?.proveedorId
+  ) {
+    return "proveedores";
+  }
+
+  if (
+    roles.some((role) => ["client", "cliente", "usuario", "colaborador"].includes(role))
+  ) {
+    return "colaboradores";
+  }
+
+  return session?.proveedorId ? "proveedores" : "colaboradores";
+};
+
+const buildPortalUrl = (session) => {
+  const portalKey = resolvePortalKey(session);
+  const base = PORTAL_BASES[TARGET] ?? PORTAL_BASES.local;
+  const baseUrl = String(base?.[portalKey] || "").replace(/\/+$/, "");
+
+  if (!baseUrl) return null;
+
+  if (portalKey === "admin") {
+    return `${baseUrl}/admin`;
+  }
+
+  return `${baseUrl}/`;
+};
+
 export default function LoginFormScreen() {
   const navigate = useNavigate();
-  const [mode, setMode] = useState("credentials");
+  const [mode, setMode] = useState("password");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const allowToken = false;
+  const allowToken = true;
+
+  const handleModeChange = (nextMode) => {
+    setMode(nextMode);
+    setError("");
+  };
+
+  const redirectToPortal = (session) => {
+    const targetUrl = buildPortalUrl(session);
+    if (targetUrl) {
+      window.location.assign(targetUrl);
+      return true;
+    }
+    return false;
+  };
 
   useEffect(() => {
     let active = true;
@@ -22,7 +99,9 @@ export default function LoginFormScreen() {
 
       if (!active) return;
       if (result?.status === "OK") {
-        navigate("/", { replace: true });
+        if (!redirectToPortal(result?.session)) {
+          navigate("/", { replace: true });
+        }
       }
     };
 
@@ -38,9 +117,14 @@ export default function LoginFormScreen() {
     setError("");
     setLoading(true);
 
-    const result = await loginWithCredentials({ usuario, password });
+    const result =
+      mode === "token"
+        ? await loginWithToken({ token })
+        : await loginWithCredentials({ usuario, password });
     if (result?.ok) {
-      navigate("/", { replace: true });
+      if (!redirectToPortal(result?.session)) {
+        navigate("/", { replace: true });
+      }
     } else {
       setError(result?.message || "No se pudo iniciar sesión");
     }
@@ -62,9 +146,9 @@ export default function LoginFormScreen() {
         <div className="flex rounded-full bg-neutral-900/70 border border-white/10 p-1">
           <button
             type="button"
-            onClick={() => setMode("credentials")}
+            onClick={() => handleModeChange("password")}
             className={`flex-1 rounded-full px-3 py-2 text-xs font-semibold transition ${
-              mode === "credentials"
+              mode === "password"
                 ? "bg-white text-black"
                 : "text-white/70 hover:text-white"
             }`}
@@ -74,6 +158,7 @@ export default function LoginFormScreen() {
           <button
             type="button"
             disabled={!allowToken}
+            onClick={() => handleModeChange("token")}
             className={`flex-1 rounded-full px-3 py-2 text-xs font-semibold transition ${
               mode === "token"
                 ? "bg-white text-black"
@@ -84,7 +169,7 @@ export default function LoginFormScreen() {
           </button>
         </div>
 
-        {mode === "credentials" && (
+        {mode === "password" && (
           <div className="space-y-3 text-left">
             <div className="space-y-1">
               <label className="text-sm text-white/70">Usuario</label>
@@ -103,6 +188,22 @@ export default function LoginFormScreen() {
                 onChange={(event) => setPassword(event.target.value)}
                 className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
                 autoComplete="current-password"
+              />
+            </div>
+          </div>
+        )}
+
+        {mode === "token" && (
+          <div className="space-y-3 text-left">
+            <div className="space-y-1">
+              <label className="text-sm text-white/70">Token</label>
+              <input
+                value={token}
+                onChange={(event) => setToken(event.target.value)}
+                className="w-full rounded-xl bg-neutral-900 border border-white/15 px-3 py-2"
+                autoComplete="one-time-code"
+                placeholder="Ingresa tu token"
+                required
               />
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Expose the already-present "Token" tab so providers can authenticate with a token while preserving the existing username/password flow.
- Redirect authenticated sessions to the appropriate portal (admin / proveedores / colaboradores) based on roles or `proveedorId`.
- Reuse existing environment configuration for portal base URLs instead of hardcoding links.
- Keep the login flows compatible and the code simple and maintainable.

### Description
- Added `loginWithToken` usage and a `token` state, changed the mode to a `password`|`token` value and added `handleModeChange` to toggle UI and behavior.
- Introduced `PORTAL_BASES`, `buildPortalUrl`, and `resolvePortalKey` helpers that compute target portal URLs from session roles and `VITE_*_PORTAL_*` env vars.
- Wired `handleSubmit` to call `loginWithToken` when `mode === "token"` and kept `loginWithCredentials` for password mode, then redirect on successful authentication via `redirectToPortal`.
- Updated the form UI to show a token input when token mode is active and enabled the Token tab (`allowToken = true`).

### Testing
- Ran `npm install` successfully with no install errors.
- Launched the dev server with `npm run dev` and confirmed Vite served the app locally.
- Executed a Playwright script that opened `/login`, clicked the "Token" tab and produced a screenshot at `artifacts/login-token.png`.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964027cb654832297c3293437086290)