### PR TITLE
Add Spanish long-date helper and show formatted vigencia under date inputs

### DIFF
--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/components/BeneficioEditModal.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/components/BeneficioEditModal.jsx
@@ -1,6 +1,7 @@
 // src/components/AdminShell/components/BeneficioEditModal.jsx
 import { useEffect, useMemo, useState } from "react";
 import { AprobacionesApi } from "../services/adminApi";
+import { formatFechaLargaES } from "../../../utils/dateFormat";
 
 export default function BeneficioEditModal({
   open,
@@ -169,6 +170,9 @@ export default function BeneficioEditModal({
                     onChange={(e) => handleChange("vigenciaInicio", e.target.value)}
                     className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
                   />
+                  <p className="text-xs text-white/50">
+                    {form.vigenciaInicio ? formatFechaLargaES(form.vigenciaInicio) : "—"}
+                  </p>
                 </div>
                 <div className="space-y-2">
                   <label className="text-xs text-white/60">Vigencia fin</label>
@@ -178,6 +182,9 @@ export default function BeneficioEditModal({
                     onChange={(e) => handleChange("vigenciaFin", e.target.value)}
                     className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
                   />
+                  <p className="text-xs text-white/50">
+                    {form.vigenciaFin ? formatFechaLargaES(form.vigenciaFin) : "—"}
+                  </p>
                 </div>
               </div>
 

--- a/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/BenefitEditModal.jsx
+++ b/clon/AdminBeneficiosFinalPublicado/src/components/AdminShell/pages/BenefitEditModal.jsx
@@ -4,6 +4,7 @@ import {
   CategoriaApi,
   ProveedorApi,
 } from "../../../services/adminApi";
+import { formatFechaLargaES } from "../../../utils/dateFormat";
 
 const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const norm = (v) => (v == null ? "" : String(v).trim());
@@ -241,6 +242,9 @@ export default function BenefitEditModal({ open, benefitId, benefit, onClose, on
                 onChange={(e) => setForm((s) => ({ ...s, vigenciaInicio: e.target.value }))}
                 disabled={formDisabled}
               />
+              <span className="text-xs text-white/50">
+                {form.vigenciaInicio ? formatFechaLargaES(form.vigenciaInicio) : "—"}
+              </span>
             </label>
             <label className="space-y-1 text-sm">
               <span className="text-white/70">Vigencia fin</span>
@@ -251,6 +255,9 @@ export default function BenefitEditModal({ open, benefitId, benefit, onClose, on
                 onChange={(e) => setForm((s) => ({ ...s, vigenciaFin: e.target.value }))}
                 disabled={formDisabled}
               />
+              <span className="text-xs text-white/50">
+                {form.vigenciaFin ? formatFechaLargaES(form.vigenciaFin) : "—"}
+              </span>
             </label>
           </div>
 

--- a/clon/AdminBeneficiosFinalPublicado/src/utils/dateFormat.js
+++ b/clon/AdminBeneficiosFinalPublicado/src/utils/dateFormat.js
@@ -1,0 +1,15 @@
+const formatter = new Intl.DateTimeFormat("es-CR", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+});
+
+export const formatFechaLargaES = (value) => {
+  if (!value) return "";
+  const normalized = String(value).trim();
+  if (!normalized) return "";
+  const dateValue = normalized.length === 10 ? `${normalized}T00:00:00` : normalized;
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+  return formatter.format(date);
+};


### PR DESCRIPTION
### Motivation

- Mostrar el mes en texto (ej. `01 de enero de 2026`) junto a los campos de vigencia sin cambiar los `input type="date"` ni alterar los datos que se envían al backend.

### Description

- Agrega un helper reutilizable `formatFechaLargaES` en `src/utils/dateFormat.js` que usa `Intl.DateTimeFormat("es-CR", { day: "2-digit", month: "long", year: "numeric" })` y acepta `YYYY-MM-DD` o strings ISO.
- Importa y usa `formatFechaLargaES` en `BeneficioEditModal.jsx` para mostrar la fecha formateada debajo de `form.vigenciaInicio` y `form.vigenciaFin` sin tocar los `input type="date"` ni cambiar los nombres de estado.
- Importa y usa `formatFechaLargaES` en `BenefitEditModal.jsx` para mostrar la fecha formateada debajo de los mismos campos en ese modal, mostrando `—` cuando no hay fecha.
- No se modificaron DTOs, APIs, lógica de guardado ni librerías externas.

### Testing

- Levanté la app en modo desarrollo con `npm run dev` y el servidor Vite arrancó correctamente (éxito).
- Ejecuté un script de Playwright que cargó la UI y tomó una captura de pantalla del modal para verificar la renderización visual (captura generada con éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697169977ee883228a95a16977eafc86)